### PR TITLE
convert PROJ error messages from bytes to strings

### DIFF
--- a/pyproj/_proj.pyx
+++ b/pyproj/_proj.pyx
@@ -91,7 +91,7 @@ cdef class Proj:
             if errcheck:
                 err = proj_errno(self.projpj)
                 if err != 0:
-                     raise ProjError(proj_errno_string(err))
+                     raise ProjError(pystrdecode(proj_errno_string(err)))
             # since HUGE_VAL can be 'inf',
             # change it to a real (but very large) number.
             # also check for NaNs.
@@ -149,7 +149,7 @@ cdef class Proj:
             if errcheck:
                 err = proj_errno(self.projpj)
                 if err != 0:
-                     raise ProjError(proj_errno_string(err))
+                     raise ProjError(pystrdecode(proj_errno_string(err)))
             # since HUGE_VAL can be 'inf',
             # change it to a real (but very large) number.
             # also check for NaNs.

--- a/pyproj/_transformer.pyx
+++ b/pyproj/_transformer.pyx
@@ -227,7 +227,7 @@ cdef class _Transformer:
         cdef int errno = proj_errno(self.projpj)
         if errno and errcheck:
             raise ProjError("proj_trans_generic error: {}".format(
-                proj_errno_string(errno)))
+                pystrdecode(proj_errno_string(errno))))
 
         # radians to degrees
         if not self.is_pipeline and not radians and self.output_radians:


### PR DESCRIPTION
As seen here: https://github.com/pyproj4/pyproj/issues/207#issuecomment-474667389.

Already used here:
https://github.com/pyproj4/pyproj/blob/b1eac98bef754edbb28fe8b080e9f8421ed61cee/pyproj/_transformer.pyx#L157
