### PR TITLE
fix proj_env in data dir tests

### DIFF
--- a/test/test_datadir.py
+++ b/test/test_datadir.py
@@ -6,6 +6,7 @@ from contextlib import contextmanager
 
 import pytest
 from mock import patch
+
 from pyproj.datadir import DataDirError, append_data_dir, get_data_dir, set_data_dir
 
 
@@ -23,8 +24,12 @@ def proj_env():
     try:
         yield
     finally:
-        if proj_lib:
+        if proj_lib is not None:
+            # add it back if it used to be there
             os.environ["PROJ_LIB"] = proj_lib
+        else:
+            # remove it if it wasn't there previously
+            os.environ.pop("PROJ_LIB", None)
 
 
 @contextmanager

--- a/test/test_datadir.py
+++ b/test/test_datadir.py
@@ -24,6 +24,8 @@ def proj_env():
     try:
         yield
     finally:
+        # make sure the data dir is cleared
+        set_data_dir(None)
         if proj_lib is not None:
             # add it back if it used to be there
             os.environ["PROJ_LIB"] = proj_lib
@@ -51,7 +53,7 @@ def test_get_data_dir__missing():
     ), patch("pyproj.datadir.find_executable", return_value=None):
         set_data_dir(None)
         os.environ.pop("PROJ_LIB", None)
-        get_data_dir()
+        assert get_data_dir() is None
 
 
 def test_get_data_dir__from_user():


### PR DESCRIPTION
Previously it was not removing the env var if it used to be there.