### PR TITLE
remove from MANIFEST.in obsolete and automatically included files

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -7,15 +7,6 @@ include pyproj/*.pyd
 include pyproj/*.pyx
 include pyproj/*.pxd
 include pyproj/*.pxi
-include test/test.py
-include test/test2.py
 include test/sample.out
-include test/datum_shift.py
-include test/test_transform.py
-include test/geodtest.py
-include test/test_datum.py
 recursive-include docs *
-recursive-include unittest *
-prune proj.4/*
 prune pyproj/proj_dir
-prune */__pycache__/


### PR DESCRIPTION
Avoid warnings for files not found.

---

I have tested `setup.py sdist` (Python 3.7.3, setuptools 40.6.3) but my interest was removing warnings - please check it creates the required tarball for releases from your workflow.

