### PR TITLE
don't define unused Sphinx html_static_path

### DIFF
--- a/sphinx/conf.py
+++ b/sphinx/conf.py
@@ -97,7 +97,7 @@ html_theme = "nature"
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ["_static"]
+# html_static_path = ["_static"]
 
 
 # -- Options for HTMLHelp output ---------------------------------------


### PR DESCRIPTION
No custom static files are used.
Avoid warning about html_static_path entry not existing.