### PR TITLE
Travis-CI: peg osx to a specific PY version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ matrix:
     - language: cpp
       os: osx
       env:
-        - PYTHON=3.6
+        - PYTHON=3.6.8
         - PROJSOURCE=6.0.0
     - python: 2.7
       env:
@@ -31,7 +31,6 @@ matrix:
         - PROJSOURCE=6.0.0
     - python: 3.7
       dist: xenial
-      sudo: true
       env:
         - PROJSOURCE=6.0.0
     - python: "nightly"


### PR DESCRIPTION
OSX was reverting to using Python 2.7.  Apparently, it needs all three numbers specified, so "3.6.8".

sudo: true is no longer needed on xenial.