### PR TITLE
CLN: remove unused _CRS.proj_version from pxd file

### DIFF
--- a/pyproj/_crs.pxd
+++ b/pyproj/_crs.pxd
@@ -46,7 +46,6 @@ cdef class _CRS:
     cdef PJ_CONTEXT * projctx
     cdef PJ_TYPE proj_type
     cdef PJ_PROJ_INFO projpj_info
-    cdef public object proj_version
     cdef char *pjinitstring
     cdef public object name
     cdef public object srs


### PR DESCRIPTION
Closes https://github.com/pyproj4/pyproj/issues/254

The `CRS` had an unused and not set attribute `proj_version`.