### PR TITLE
CI: use --no-use-pep517 to keep using editable install with pip 19.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -73,7 +73,7 @@ before_install:
 install:
   # coverage report requires a local install
   - pip install "pip>=10.0.1"
-  - PYPROJ_FULL_COVERAGE=YES pip install -e .
+  - PYPROJ_FULL_COVERAGE=YES pip install -e . --no-use-pep517
   - pip install -r requirements-dev.txt
   - pip install coveralls
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -73,9 +73,9 @@ before_install:
 install:
   # coverage report requires a local install
   - pip install "pip>=10.0.1"
-  - pip install -r requirements-dev.txt
-  - PYPROJ_FULL_COVERAGE=YES pip install -e . --no-use-pep517
+  - PYPROJ_FULL_COVERAGE=YES pip install .
   - pip install coveralls
+  - pip install -r requirements-dev.txt
 
 script:
   - python -c "import pyproj; pyproj.Proj(init='epsg:4269')"

--- a/.travis.yml
+++ b/.travis.yml
@@ -73,8 +73,8 @@ before_install:
 install:
   # coverage report requires a local install
   - pip install "pip>=10.0.1"
-  - PYPROJ_FULL_COVERAGE=YES pip install -e . --no-use-pep517
   - pip install -r requirements-dev.txt
+  - PYPROJ_FULL_COVERAGE=YES pip install -e . --no-use-pep517
   - pip install coveralls
 
 script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -85,9 +85,9 @@ build_script:
   - proj
   # Build and install pyproj
   - "%CMD_IN_ENV% pip install \"pip>=10.0.1\""
+  - "%CMD_IN_ENV% pip install -r requirements-dev.txt"
   - set PYPROJ_FULL_COVERAGE=YES
   - "%CMD_IN_ENV% pip install -e . --no-use-pep517"
-  - "%CMD_IN_ENV% pip install -r requirements-dev.txt"
 
 
 install:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -86,7 +86,7 @@ build_script:
   # Build and install pyproj
   - "%CMD_IN_ENV% pip install \"pip>=10.0.1\""
   - set PYPROJ_FULL_COVERAGE=YES
-  - "%CMD_IN_ENV% pip install -e ."
+  - "%CMD_IN_ENV% pip install -e . --no-use-pep517"
   - "%CMD_IN_ENV% pip install -r requirements-dev.txt"
 
 


### PR DESCRIPTION
Change in the recently released pip requires adding this flag if you want to editable install mode in presence of a pyproject.toml file