### PR TITLE
CI: pin pip < 19.1 to avoid breakage of editable install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -72,7 +72,7 @@ before_install:
 
 install:
   # coverage report requires a local install
-  - pip install "pip>=10.0.1"
+  - pip install "pip>=10.0.1,<19.1"
   - PYPROJ_FULL_COVERAGE=YES pip install -e .
   - pip install -r requirements-dev.txt
   - pip install coveralls

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -84,7 +84,7 @@ build_script:
   - cd %APPVEYOR_BUILD_FOLDER%
   - proj
   # Build and install pyproj
-  - "%CMD_IN_ENV% pip install \"pip>=10.0.1\""
+  - "%CMD_IN_ENV% pip install \"pip>=10.0.1,<19.1\""
   - set PYPROJ_FULL_COVERAGE=YES
   - "%CMD_IN_ENV% pip install -e ."
   - "%CMD_IN_ENV% pip install -r requirements-dev.txt"
@@ -109,7 +109,7 @@ install:
 
   # Upgrade to the latest version of pip to avoid it displaying warnings
   # about it being out of date.
-  - "pip install --disable-pip-version-check --user --upgrade pip"
+  - "pip install --disable-pip-version-check --user --upgrade pip==19.0.3"
   
   # install wheel, caching
   - "%CMD_IN_ENV% pip install wheel"


### PR DESCRIPTION
Alternative / easier, temporary fix for https://github.com/pyproj4/pyproj/pull/282 by just pinning pip, since they are still discussing whether to fix this on the pip side (https://github.com/pypa/pip/issues/6434)