### PR TITLE
_CRS to CCRS to make accessible to user as it is potentially useful for a user

### DIFF
--- a/docs/api/crs.rst
+++ b/docs/api/crs.rst
@@ -68,3 +68,12 @@ Prime Meridian
 .. autoclass:: pyproj.crs.PrimeMeridian
     :members:
     :inherited-members:
+
+
+Cython CRS Base Class
+---------------------
+This is for those who want direct access to passing a string to `proj_create`
+without any helpful filtering.
+
+.. autoclass:: pyproj.crs.CCRS
+    :members:

--- a/pyproj/_crs.pxd
+++ b/pyproj/_crs.pxd
@@ -106,7 +106,7 @@ cdef class CoordinateOperation(Base):
     cdef create(PJ* coordinate_operation_pj)
 
 
-cdef class _CRS(Base):
+cdef class CCRS(Base):
     cdef PJ_TYPE _type
     cdef PJ_PROJ_INFO projpj_info
     cdef char *pjinitstring

--- a/pyproj/_transformer.pyx
+++ b/pyproj/_transformer.pyx
@@ -1,6 +1,6 @@
 include "base.pxi"
 
-from pyproj._crs cimport _CRS
+from pyproj._crs cimport CCRS
 from pyproj._datadir cimport get_pyproj_context
 from pyproj.compat import cstrencode, pystrdecode
 from pyproj.enums import TransformDirection
@@ -51,7 +51,7 @@ cdef class _Transformer:
         })
 
     @staticmethod
-    def from_crs(_CRS crs_from, _CRS crs_to, skip_equivalent=False, always_xy=False):
+    def from_crs(CCRS crs_from, CCRS crs_to, skip_equivalent=False, always_xy=False):
         cdef _Transformer transformer = _Transformer()
         transformer.projpj = proj_create_crs_to_crs(
             transformer.projctx,


### PR DESCRIPTION
This may be useful for someone who just wants a direct interface to `proj_create` with a slim version of the CRS class:
```
>>> from pyproj.crs import CCRS
>>> cc = CCRS("epsg:4326")
>>> cc
GEOGCRS["WGS 84",
    DATUM["World Geodetic System 1984",
        ELLIPSOID["WGS 84",6378137,298.257223563,
            LENGTHUNIT["metre",1]]],
    PRIMEM["Greenwich",0,
        ANGLEUNIT["degree",0.0174532925199433]],
    CS[ellipsoidal,2],
        AXIS["geodetic latitude (Lat)",north,
            ORDER[1],
            ANGLEUNIT["degree",0.0174532925199433]],
        AXIS["geodetic longitude (Lon)",east,
            ORDER[2],
            ANGLEUNIT["degree",0.0174532925199433]],
    USAGE[
        SCOPE["unknown"],
        AREA["World"],
        BBOX[-90,-180,90,180]],
    ID["EPSG",4326]]
>>> cc.to_proj4()
'+proj=longlat +datum=WGS84 +no_defs +type=crs'
```