### PR TITLE
Only require aenum for python < 3.6 versions

### DIFF
--- a/pyproj/enums.py
+++ b/pyproj/enums.py
@@ -1,7 +1,13 @@
 """
 This module contains enumerations used in pyproj.
 """
-from aenum import Enum
+import sys
+
+if sys.version_info >= (3, 6):
+    from enum import Enum
+else:
+    # _missing_ was only added in Python 3.6, using aenum for older versions
+    from aenum import Enum
 
 from pyproj.compat import string_types
 

--- a/setup.py
+++ b/setup.py
@@ -235,5 +235,5 @@ Optimized for numpy arrays.""",
     packages=["pyproj"],
     ext_modules=get_extension_modules(),
     package_data=get_package_data(),
-    install_requires=["aenum"],
+    install_requires=['aenum;python_version<"3.6"'],
 )


### PR DESCRIPTION
Thought to make this dependency conditional, like before for enum34 was also done.