### PR TITLE
fix testProj4Version for Proj.proj_version being an integer

### DIFF
--- a/test/test.py
+++ b/test/test.py
@@ -13,7 +13,7 @@ from pyproj.crs import CRSError
 class BasicTest(unittest.TestCase):
     def testProj4Version(self):
         awips221 = Proj(proj="lcc", R=6371200, lat_1=50, lat_2=50, lon_0=-107)
-        assert re.match(r"\d+\.\d+", awips221.proj_version)
+        assert type(awips221.proj_version) is int
 
     def testInitWithBackupString4(self):
         # this fails unless backup of to_string(4) is used


### PR DESCRIPTION
```
ERROR: testProj4Version (__main__.BasicTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test/test.py", line 16, in testProj4Version
    assert re.match(r"\d+\.\d+", awips221.proj_version)
  File "/usr/lib/python3.7/re.py", line 173, in match
    return _compile(pattern, flags).match(string)
TypeError: expected string or bytes-like object
```