### PR TITLE
update data dir exception handling to prevent ignoring errors

### DIFF
--- a/docs/history.rst
+++ b/docs/history.rst
@@ -8,6 +8,7 @@ Change Log
 * Fixed case in :meth:`~pyproj.crs.CRS.to_dict` with :meth:`~pyproj.crs.CRS.to_proj4` returning None (pull #359)
 * Keep `no_defs` in input PROJ string as it does not hurt/help anything in current code (pull #359)
 * Made public properties on C classes readonly (pull #359)
+* Update data dir exception handling to prevent ignoring errors (pull #361)
 
 2.2.1
 ~~~~~

--- a/pyproj/_crs.pyx
+++ b/pyproj/_crs.pyx
@@ -298,7 +298,7 @@ cdef class AreaOfUse:
 cdef class Base:
     def __cinit__(self):
         self.projobj = NULL
-        self.projctx = get_pyproj_context()
+        self.projctx = NULL
         self.name = "undefined"
 
     def __dealloc__(self):
@@ -307,6 +307,9 @@ cdef class Base:
             proj_destroy(self.projobj)
         if self.projctx != NULL:
             proj_context_destroy(self.projctx)
+
+    def __init__(self):
+        self.projctx = get_pyproj_context()
 
     def _set_name(self):
         """
@@ -1302,6 +1305,7 @@ cdef class _CRS(Base):
         self.type_name = "undefined"
 
     def __init__(self, proj_string):
+        self.projctx = get_pyproj_context()
         # initialize projection
         self.projobj = proj_create(self.projctx, cstrencode(proj_string))
         if self.projobj is NULL:

--- a/pyproj/_datadir.pxd
+++ b/pyproj/_datadir.pxd
@@ -1,3 +1,3 @@
 include "proj.pxi"
 
-cdef PJ_CONTEXT* get_pyproj_context()
+cdef PJ_CONTEXT* get_pyproj_context() except *

--- a/pyproj/_datadir.pyx
+++ b/pyproj/_datadir.pyx
@@ -14,7 +14,7 @@ cdef void pyproj_log_function(void *user_data, int level, const char *error_msg)
         ProjError.internal_proj_error = pystrdecode(error_msg)
 
 
-cdef PJ_CONTEXT* get_pyproj_context():
+cdef PJ_CONTEXT* get_pyproj_context() except *:
     data_dir = get_data_dir()
     data_dir_list = data_dir.split(os.pathsep)
     cdef PJ_CONTEXT* pyproj_context = NULL

--- a/pyproj/_transformer.pyx
+++ b/pyproj/_transformer.pyx
@@ -1,7 +1,6 @@
 include "base.pxi"
 
 from pyproj._crs cimport Base, _CRS
-from pyproj._datadir cimport get_pyproj_context
 from pyproj.compat import cstrencode, pystrdecode
 from pyproj.enums import ProjVersion, TransformDirection
 from pyproj.exceptions import ProjError

--- a/pyproj/datadir.py
+++ b/pyproj/datadir.py
@@ -96,7 +96,7 @@ def get_data_dir():
 
     if _VALIDATED_PROJ_DATA is None:
         raise DataDirError(
-            "Valid PROJ data directory not found."
+            "Valid PROJ data directory not found. "
             "Either set the path using the environmental variable PROJ_LIB or "
             "with `pyproj.datadir.set_data_dir`."
         )


### PR DESCRIPTION
Before:
```
Exception ignored in: 'pyproj._datadir.get_pyproj_context'
Traceback (most recent call last):
  File "/home/snowal/scripts/pyproj/pyproj/datadir.py", line 99, in get_data_dir
    "Valid PROJ data directory not found."
pyproj.exceptions.DataDirError: Valid PROJ data directory not found.Either set the path using the environmental variable PROJ_LIB or with `pyproj.datadir.set_data_dir`.
proj_create: Cannot find proj.db
proj_create: no database context specified
...
```
After:
```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/snowal/scripts/pyproj/pyproj/crs.py", line 302, in __init__
    super(CRS, self).__init__(projstring)
  File "pyproj/_crs.pyx", line 1308, in pyproj._crs._CRS.__init__
    self.projctx = get_pyproj_context()
  File "pyproj/_datadir.pyx", line 18, in pyproj._datadir.get_pyproj_context
    data_dir = get_data_dir()
  File "/home/snowal/scripts/pyproj/pyproj/datadir.py", line 99, in get_data_dir
    "Valid PROJ data directory not found."
pyproj.exceptions.DataDirError: Valid PROJ data directory not found.Either set the path using the environmental variable PROJ_LIB or with `pyproj.datadir.set_data_dir`.

```