### PR TITLE
CRS.to_cf export transverse mercator parameters for UTM zones

### DIFF
--- a/docs/history.rst
+++ b/docs/history.rst
@@ -9,6 +9,7 @@ Change Log
 * Keep `no_defs` in input PROJ string as it does not hurt/help anything in current code (pull #359)
 * Made public properties on C classes readonly (pull #359)
 * Update data dir exception handling to prevent ignoring errors (pull #361)
+* :meth:`~pyproj.crs.CRS.to_cf` export transverse mercator parameters for UTM zones (pull #362)
 
 2.2.1
 ~~~~~

--- a/pyproj/cf1x8.py
+++ b/pyproj/cf1x8.py
@@ -82,3 +82,21 @@ K_0_MAP = {
     "DEFAULT": "scale_factor_at_projection_origin",
     "transverse_mercator": "scale_factor_at_central_meridian",
 }
+
+
+METHOD_NAME_TO_CF_MAP = {"Transverse Mercator": "transverse_mercator"}
+
+
+PARAM_TO_CF_MAP = {
+    "Latitude of natural origin": "latitude_of_projection_origin",
+    "Longitude of natural origin": "longitude_of_central_meridian",
+    "Latitude of false origin": "latitude_of_projection_origin",
+    "Longitude of false origin": "longitude_of_central_meridian",
+    "Scale factor at natural origin": "scale_factor_at_central_meridian",
+    "Easting at projection centre": "false_easting",
+    "Northing at projection centre": "false_northing",
+    "Easting at false origin": "fase_easting",
+    "Northing at false origin": "fase_northing",
+    "False easting": "false_easting",
+    "False northing": "false_northing",
+}

--- a/pyproj/crs.py
+++ b/pyproj/crs.py
@@ -45,6 +45,8 @@ from pyproj.cf1x8 import (
     K_0_MAP,
     LON_0_MAP,
     PROJ_PARAM_MAP,
+    PARAM_TO_CF_MAP,
+    METHOD_NAME_TO_CF_MAP,
 )
 from pyproj.compat import string_types
 from pyproj.exceptions import CRSError
@@ -545,6 +547,18 @@ class CRS(_CRS):
         if grid_mapping_name == "rotated_latitude_longitude":
             if proj_dict.pop("o_proj") not in lonlat_possible_names:
                 grid_mapping_name = "unknown"
+
+        # derive parameters from the coordinate operation
+        if (
+            grid_mapping_name == "unknown"
+            and self.coordinate_operation
+            and self.coordinate_operation.method_name in METHOD_NAME_TO_CF_MAP
+        ):
+            grid_mapping_name = METHOD_NAME_TO_CF_MAP[
+                self.coordinate_operation.method_name
+            ]
+            for param in self.coordinate_operation.params:
+                cf_dict[PARAM_TO_CF_MAP[param.name]] = param.value
 
         cf_dict["grid_mapping_name"] = grid_mapping_name
 

--- a/test/test_crs_cf.py
+++ b/test/test_crs_cf.py
@@ -110,8 +110,31 @@ def test_cf_from_utm():
     assert cf_dict.pop("crs_wkt").startswith("PROJCRS[")
     assert cf_dict == {
         "projected_crs_name": "WGS 84 / UTM zone 15N",
-        "grid_mapping_name": "unknown",
+        "latitude_of_projection_origin": 0.0,
+        "longitude_of_central_meridian": -93.0,
+        "scale_factor_at_central_meridian": 0.9996,
+        "false_easting": 500000.0,
+        "false_northing": 0.0,
+        "grid_mapping_name": "transverse_mercator",
         "horizontal_datum_name": "WGS84",
+        "unit": "m",
+    }
+
+
+def test_cf_from_utm__nad83():
+    crs = CRS("epsg:26917")
+    with pytest.warns(UserWarning):
+        cf_dict = crs.to_cf(errcheck=True)
+    assert cf_dict.pop("crs_wkt").startswith("PROJCRS[")
+    assert cf_dict == {
+        "projected_crs_name": "NAD83 / UTM zone 17N",
+        "latitude_of_projection_origin": 0.0,
+        "longitude_of_central_meridian": -81.0,
+        "scale_factor_at_central_meridian": 0.9996,
+        "false_easting": 500000.0,
+        "false_northing": 0.0,
+        "grid_mapping_name": "transverse_mercator",
+        "horizontal_datum_name": "NAD83",
         "unit": "m",
     }
 


### PR DESCRIPTION
 - [x] Tests added
 - [x] Fully documented, including `history.rst` for all changes and `api/*.rst` for new API