### PR TITLE
Minimum supported Python version 3.5; removed aenum dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,9 +27,6 @@ matrix:
       env:
         - PYTHON=3.6.8
         - PROJSOURCE=6.1.1
-    - python: 2.7
-      env:
-        - PROJSOURCE=6.1.1
     - python: 3.5
       env:
         - PROJSOURCE=6.1.1

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -3,6 +3,8 @@ Change Log
 
 2.3.0
 ~~~~~
+* Minimum supported Python version 3.5 (issue #331)
+* Remove aenum dependency (issue #339)
 * Added support for calculating geodesic area (:meth:`~pyproj.geod.Geod.polygon_area_perimeter`)
   and added interface to calculate total length of a line 
   (:meth:`~pyproj.geod.Geod.line_length` & :meth:`~pyproj.geod.Geod.line_lengths`) (issue #210).
@@ -10,6 +12,7 @@ Change Log
   (:meth:`~pyproj.geod.Geod.geometry_area_perimeter` & :meth:`~pyproj.geod.Geod.geometry_length`)
   (pull #366)
 * Removed deprecated functions `Proj.proj_version`, `CRS.is_valid`, and `CRS.to_geodetic()` (pull #371)
+
 
 2.2.2
 ~~~~~

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -5,6 +5,8 @@ Python interface to  `PROJ <https://proj.org/>`_ (cartographic projections and c
 
 .. note:: Minimum supported PROJ version is 6.1.0
 
+.. note:: Minimum supported Python version is 3.5
+
 GitHub Repository: https://github.com/pyproj4/pyproj
 
 

--- a/pyproj/_crs.pyx
+++ b/pyproj/_crs.pyx
@@ -79,7 +79,7 @@ cdef _to_wkt(PJ_CONTEXT* projctx, PJ* projobj, version=WktVersion.WKT2_2018, pre
         WktVersion.WKT1_ESRI: PJ_WKT1_ESRI
     }
     cdef PJ_WKT_TYPE wkt_out_type
-    wkt_out_type = supported_wkt_types[WktVersion(version)]
+    wkt_out_type = supported_wkt_types[WktVersion.create(version)]
  
     cdef const char* options_wkt[2]
     multiline = b"MULTILINE=NO"
@@ -115,7 +115,7 @@ cdef _to_proj4(PJ_CONTEXT* projctx, PJ* projobj, version):
         ProjVersion.PROJ_5: PJ_PROJ_5,
     }
     cdef PJ_PROJ_STRING_TYPE proj_out_type
-    proj_out_type = supported_prj_types[ProjVersion(version)]
+    proj_out_type = supported_prj_types[ProjVersion.create(version)]
 
     # convert projection to string
     cdef const char* proj_string

--- a/pyproj/_transformer.pyx
+++ b/pyproj/_transformer.pyx
@@ -118,7 +118,7 @@ cdef class _Transformer(Base):
     def _transform(self, inx, iny, inz, intime, direction, radians, errcheck):
         if self.projections_exact_same or (self.projections_equivalent and self.skip_equivalent):
             return
-        tmp_pj_direction = _PJ_DIRECTION_MAP[TransformDirection(direction)]
+        tmp_pj_direction = _PJ_DIRECTION_MAP[TransformDirection.create(direction)]
         cdef PJ_DIRECTION pj_direction = <PJ_DIRECTION>tmp_pj_direction
         # private function to call pj_transform
         cdef void *xdata
@@ -211,7 +211,7 @@ cdef class _Transformer(Base):
     ):
         if self.projections_exact_same or (self.projections_equivalent and self.skip_equivalent):
             return
-        tmp_pj_direction = _PJ_DIRECTION_MAP[TransformDirection(direction)]
+        tmp_pj_direction = _PJ_DIRECTION_MAP[TransformDirection.create(direction)]
         cdef PJ_DIRECTION pj_direction = <PJ_DIRECTION>tmp_pj_direction
         # private function to itransform function
         cdef:

--- a/pyproj/compat.py
+++ b/pyproj/compat.py
@@ -1,11 +1,4 @@
 # -*- coding: utf-8 -*-
-import sys
-
-# Python 2/3 compatibility
-if sys.version_info[0] == 2:  # Python 2
-    string_types = (basestring,)  # noqa: F821
-else:  # Python 3
-    string_types = (str,)
 
 
 def cstrencode(pystr):
@@ -24,9 +17,7 @@ def pystrdecode(cstr):
     """
     Decode a string to a python string.
     """
-    if sys.version_info[0] > 2:
-        try:
-            return cstr.decode("utf-8")
-        except AttributeError:
-            pass
-    return cstr
+    try:
+        return cstr.decode("utf-8")
+    except AttributeError:
+        return cstr

--- a/pyproj/crs.py
+++ b/pyproj/crs.py
@@ -48,7 +48,6 @@ from pyproj.cf1x8 import (
     PARAM_TO_CF_MAP,
     PROJ_PARAM_MAP,
 )
-from pyproj.compat import string_types
 from pyproj.exceptions import CRSError
 from pyproj.geod import Geod
 
@@ -286,7 +285,7 @@ class CRS(_CRS):
         >>> crs.is_geographic
         False
         """
-        if isinstance(projparams, string_types):
+        if isinstance(projparams, str):
             projstring = _prepare_from_string(projparams)
         elif isinstance(projparams, dict):
             projstring = _prepare_from_dict(projparams)

--- a/pyproj/enums.py
+++ b/pyproj/enums.py
@@ -1,21 +1,17 @@
 """
 This module contains enumerations used in pyproj.
 """
-import sys
-
-from pyproj.compat import string_types
-
-if sys.version_info >= (3, 6):
-    from enum import Enum
-else:
-    # _missing_ was only added in Python 3.6, using aenum for older versions
-    from aenum import Enum
+from enum import Enum
 
 
 class BaseEnum(Enum):
     @classmethod
-    def _missing_(cls, item):
-        if isinstance(item, string_types):
+    def create(cls, item):
+        try:
+            return cls(item)
+        except ValueError:
+            pass
+        if isinstance(item, str):
             item = item.upper()
         for member in cls:
             if member.value == item:

--- a/setup.py
+++ b/setup.py
@@ -221,8 +221,6 @@ setup(
         "Development Status :: 4 - Beta",
         "Intended Audience :: Science/Research",
         "License :: OSI Approved",
-        "Programming Language :: Python :: 2",
-        "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
@@ -233,7 +231,7 @@ setup(
         "Operating System :: OS Independent",
     ],
     packages=["pyproj"],
+    python_requires=">=3.5",
     ext_modules=get_extension_modules(),
     package_data=get_package_data(),
-    install_requires=['aenum;python_version<"3.6"'],
 )


### PR DESCRIPTION
 - [x] Closes #331 & #339
 - [x] Fully documented, including `history.rst` for all changes and `api/*.rst` for new API