### PR TITLE
remove parallel omp cython code & parallel CICD matrix items

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,12 +27,6 @@ matrix:
       env:
         - PYTHON=3.6.8
         - PROJSOURCE=6.1.1
-    - language: cpp
-      os: osx
-      env:
-        - PYTHON=3.6.8
-        - PROJSOURCE=6.1.1
-        - PYPROJ_OMP="-fopenmp"
     - python: 3.5
       env:
         - PROJSOURCE=6.1.1
@@ -42,10 +36,6 @@ matrix:
     - python: 3.6
       env:
         - PROJSOURCE=6.1.1
-    - python: 3.6
-      env: 
-        - PROJSOURCE=6.1.1
-        - PYPROJ_OMP="-fopenmp"
     - python: 3.7
       dist: xenial
       env:
@@ -59,16 +49,6 @@ matrix:
     - python: "nightly"
       env:
         - PROJSOURCE=git
-    - language: cpp
-      os: osx
-      env:
-        - PYTHON=3.6.8
-        - PROJSOURCE=6.1.1
-        - PYPROJ_OMP="-fopenmp"
-    - python: 3.6
-      env: 
-        - PROJSOURCE=6.1.1
-        - PYPROJ_OMP="-fopenmp"
 
 
 before_install:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -56,8 +56,6 @@ cache:
     - "%PROJ_BASE_DIR%"
 
 build_script:
-  # update vcpkg
-  - .\bootstrap-vcpkg.bat
   # setup sqlite3
   - set PROJ_DIR=%PROJ_BASE_DIR%\proj-%PROJSOURCE:~0,5%
   - vcpkg install sqlite3:"%platform%"-windows
@@ -125,6 +123,12 @@ install:
   
   # install wheel, caching
   - "%CMD_IN_ENV% pip install wheel"
+  # update vcpkg
+  - cmd: |
+      cd "C:\Tools\vcpkg"
+      git pull
+      .\bootstrap-vcpkg.bat
+      cd %APPVEYOR_BUILD_FOLDER%
 
 test_script:
   # Run the project tests

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -40,14 +40,14 @@ environment:
     #   VS_VERSION: Visual Studio 14
     #   APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
     #   PROJSOURCE: git
-matrix:
-  allow_failures:
-    # - PYTHON: "C:\\Python36-x64"
-    #   PYTHON_VERSION: "3.6"
-    #   PYTHON_ARCH: "64"
-    #   VS_VERSION: Visual Studio 14
-    #   APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-    #   PROJSOURCE: git
+# matrix:
+#   allow_failures:
+#     - PYTHON: "C:\\Python36-x64"
+#       PYTHON_VERSION: "3.6"
+#       PYTHON_ARCH: "64"
+#       VS_VERSION: Visual Studio 14
+#       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+#       PROJSOURCE: git
 
 shallow_clone: true
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,13 +28,6 @@ environment:
       VS_VERSION: Visual Studio 14
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
       PROJSOURCE: 6.1.1
-    - PYTHON: "C:\\Python36-x64"
-      PYTHON_VERSION: "3.6"
-      PYTHON_ARCH: "64"
-      VS_VERSION: Visual Studio 14
-      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-      PROJSOURCE: 6.1.1
-      PYPROJ_OMP: "/openmp"
   # - PYTHON: "C:\\Python37-x64"
     #   PYTHON_VERSION: "3.7"
     #   PYTHON_ARCH: "64"
@@ -49,13 +42,12 @@ environment:
     #   PROJSOURCE: git
 matrix:
   allow_failures:
-    - PYTHON: "C:\\Python36-x64"
-      PYTHON_VERSION: "3.6"
-      PYTHON_ARCH: "64"
-      VS_VERSION: Visual Studio 14
-      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-      PROJSOURCE: 6.1.1
-      PYPROJ_OMP: "/openmp"
+    # - PYTHON: "C:\\Python36-x64"
+    #   PYTHON_VERSION: "3.6"
+    #   PYTHON_ARCH: "64"
+    #   VS_VERSION: Visual Studio 14
+    #   APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+    #   PROJSOURCE: git
 
 shallow_clone: true
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -56,6 +56,8 @@ cache:
     - "%PROJ_BASE_DIR%"
 
 build_script:
+  # update vcpkg
+  - .\bootstrap-vcpkg.bat
   # setup sqlite3
   - set PROJ_DIR=%PROJ_BASE_DIR%\proj-%PROJSOURCE:~0,5%
   - vcpkg install sqlite3:"%platform%"-windows

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -81,29 +81,6 @@ The order of preference for the data directory is:
 3. The directory in PROJ_LIB (if exists & valid)
 4. The directory on the PATH (if exists & valid)
 
-Optional: Enable OpenMP
-~~~~~~~~~~~~~~~~~~~~~~~
-
-You will need to have OpenMP installed beforehand for this to work.
-
-.. versionadded:: 2.3
-    OpenMP parallel experimental support with Cython for subset of code.
-
-
-.. warning:: Enabling OpenMP has been unstable in some circumstances.
-
-
-Then, depending on your compiler, you will need to set the openmp flag
-before installing pyproj.
-
-gcc compiler::
-
-  export PYPROJ_OMP="-fopenmp"
-
-Microsoft Visual C++ compiler::
-
-  set PYPROJ_OMP='/openmp'
-
 
 Install pyproj
 ~~~~~~~~~~~~~~

--- a/pyproj/_geod.pxd
+++ b/pyproj/_geod.pxd
@@ -3,21 +3,21 @@ cdef extern from "geodesic.h":
         pass
   struct geod_geodesicline:
         pass
-  void geod_init(geod_geodesic* g, double a, double f) nogil
+  void geod_init(geod_geodesic* g, double a, double f)
   void geod_direct(geod_geodesic* g,
               double lat1, double lon1, double azi1, double s12,
-              double* plat2, double* plon2, double* pazi2) nogil
+              double* plat2, double* plon2, double* pazi2)
   void geod_inverse(geod_geodesic* g,
                double lat1, double lon1, double lat2, double lon2,
-               double* ps12, double* pazi1, double* pazi2) nogil
+               double* ps12, double* pazi1, double* pazi2)
   void geod_lineinit(geod_geodesicline* l,
                geod_geodesic* g,
-               double lat1, double lon1, double azi1, unsigned caps) nogil
+               double lat1, double lon1, double azi1, unsigned caps)
   void geod_position(geod_geodesicline* l, double s12,
-               double* plat2, double* plon2, double* pazi2) nogil
+               double* plat2, double* plon2, double* pazi2)
   void geod_polygonarea(geod_geodesic* g,
                         double lats[], double lons[], int n,
-                        double* pA, double* pP) nogil
+                        double* pA, double* pP)
 
   cdef enum:
       GEODESIC_VERSION_MAJOR

--- a/pyproj/_geod.pyx
+++ b/pyproj/_geod.pyx
@@ -1,7 +1,6 @@
 include "base.pxi"
 
 cimport cython
-from cython.parallel import prange
 
 from pyproj.compat import cstrencode, pystrdecode
 from pyproj.exceptions import GeodError
@@ -67,7 +66,7 @@ cdef class Geod:
         latsdata = <double *>latdata
         azdata = <double *>azdat
         distdata = <double *>distdat
-        for iii in prange(ndim, nogil=True):
+        for iii in range(ndim):
             if not radians:
                 lon1 = lonsdata[iii]
                 lat1 = latsdata[iii]
@@ -130,7 +129,7 @@ cdef class Geod:
         latsdata = <double *>latdata
         azdata = <double *>azdat
         distdata = <double *>distdat
-        for iii in prange(ndim, nogil=True):
+        for iii in range(ndim):
             if radians:
                 lon1 = _RAD2DG * lonsdata[iii]
                 lat1 = _RAD2DG * latsdata[iii]
@@ -244,7 +243,7 @@ cdef class Geod:
             lonsdata[0] = 0
             return 0.0
 
-        for iii in prange(ndim - 1, nogil=True):
+        for iii in range(ndim - 1):
             if radians:
                 lon1 = _RAD2DG * lonsdata[iii]
                 lat1 = _RAD2DG * latsdata[iii]
@@ -312,7 +311,7 @@ cdef class Geod:
         lonsdata = <double *>londata
         latsdata = <double *>latdata
         if radians:
-            for iii in prange(ndim, nogil=True):
+            for iii in range(ndim):
                 lonsdata[iii] *= _RAD2DG
                 latsdata[iii] *= _RAD2DG
 

--- a/pyproj/_proj.pyx
+++ b/pyproj/_proj.pyx
@@ -3,7 +3,6 @@ include "base.pxi"
 import warnings
 
 cimport cython
-from cython.parallel import prange
 
 from pyproj.compat import cstrencode, pystrdecode
 from pyproj._datadir cimport PROJ_CONTEXT
@@ -76,13 +75,12 @@ cdef class Proj:
         ndim = buflenx//_DOUBLESIZE
         lonsdata = <double *>londata
         latsdata = <double *>latdata
-        for iii in prange(ndim, nogil=True):
+        for iii in range(ndim):
             # if inputs are nan's, return big number.
             if lonsdata[iii] != lonsdata[iii] or latsdata[iii] != latsdata[iii]:
                 lonsdata[iii]=1.e30; latsdata[iii]=1.e30
                 if errcheck:
-                    with gil:
-                        raise ProjError("projection_undefined")
+                    raise ProjError("projection_undefined")
                 continue
             if proj_angular_input(self.projpj, PJ_FWD):
                 projlonlatin.uv.u = _DG2RAD * lonsdata[iii]
@@ -94,8 +92,7 @@ cdef class Proj:
             if errcheck:
                 err = proj_errno(self.projpj)
                 if err != 0:
-                    with gil:
-                        raise ProjError(pystrdecode(proj_errno_string(err)))
+                    raise ProjError(pystrdecode(proj_errno_string(err)))
             # since HUGE_VAL can be 'inf',
             # change it to a real (but very large) number.
             # also check for NaNs.
@@ -104,8 +101,7 @@ cdef class Proj:
                     projxyout.xy.y == HUGE_VAL or\
                     projxyout.xy.x != projxyout.xy.x:
                 if errcheck:
-                    with gil:
-                        raise ProjError("projection_undefined")
+                    raise ProjError("projection_undefined")
                 lonsdata[iii] = 1.e30
                 latsdata[iii] = 1.e30
             elif proj_angular_output(self.projpj, PJ_FWD):
@@ -149,13 +145,12 @@ cdef class Proj:
         ndim = buflenx//_DOUBLESIZE
         xdatab = <double *>xdata
         ydatab = <double *>ydata
-        for iii in prange(ndim, nogil=True):
+        for iii in range(ndim):
             # if inputs are nan's, return big number.
             if xdatab[iii] != xdatab[iii] or ydatab[iii] != ydatab[iii]:
                 xdatab[iii]=1.e30; ydatab[iii]=1.e30
                 if errcheck:
-                    with gil:
-                        raise ProjError("projection_undefined")
+                    raise ProjError("projection_undefined")
                 continue
             if proj_angular_input(self.projpj, PJ_INV):
                 projxyin.uv.u = _DG2RAD * xdatab[iii]
@@ -167,8 +162,7 @@ cdef class Proj:
             if errcheck:
                 err = proj_errno(self.projpj)
                 if err != 0:
-                    with gil:
-                        raise ProjError(pystrdecode(proj_errno_string(err)))
+                    raise ProjError(pystrdecode(proj_errno_string(err)))
             # since HUGE_VAL can be 'inf',
             # change it to a real (but very large) number.
             # also check for NaNs.
@@ -177,8 +171,7 @@ cdef class Proj:
                     projlonlatout.uv.v == HUGE_VAL or \
                     projlonlatout.uv.v != projlonlatout.uv.v:
                 if errcheck:
-                    with gil:
-                        raise ProjError("projection_undefined")
+                    raise ProjError("projection_undefined")
                 xdatab[iii] = 1.e30
                 ydatab[iii] = 1.e30
             elif proj_angular_output(self.projpj, PJ_INV):

--- a/pyproj/_transformer.pyx
+++ b/pyproj/_transformer.pyx
@@ -1,7 +1,6 @@
 include "base.pxi"
 
 cimport cython
-from cython.parallel import prange
 
 from pyproj._crs cimport Base, _CRS, CoordinateOperation
 from pyproj._datadir cimport PROJ_CONTEXT
@@ -277,14 +276,14 @@ cdef class _Transformer(Base):
         # degrees to radians
         if not self.is_pipeline and not radians\
                 and self._input_radians[pj_direction]:
-            for iii in prange(npts, nogil=True):
+            for iii in range(npts):
                 xx[iii] = xx[iii]*_DG2RAD
                 yy[iii] = yy[iii]*_DG2RAD
         # radians to degrees
         elif not self.is_pipeline and radians\
                 and not self._input_radians[pj_direction]\
                 and self.input_geographic:
-            for iii in prange(npts, nogil=True):
+            for iii in range(npts):
                 xx[iii] = xx[iii]*_RAD2DG
                 yy[iii] = yy[iii]*_RAD2DG
 
@@ -308,14 +307,14 @@ cdef class _Transformer(Base):
         # radians to degrees
         if not self.is_pipeline and not radians\
                 and self._output_radians[pj_direction]:
-            for iii in prange(npts, nogil=True):
+            for iii in range(npts):
                 xx[iii] = xx[iii]*_RAD2DG
                 yy[iii] = yy[iii]*_RAD2DG
         # degrees to radians
         elif not self.is_pipeline and radians\
                 and not self._output_radians[pj_direction]\
                 and self.output_geographic:
-            for iii in prange(npts, nogil=True):
+            for iii in range(npts):
                 xx[iii] = xx[iii]*_DG2RAD
                 yy[iii] = yy[iii]*_DG2RAD
 
@@ -351,7 +350,7 @@ cdef class _Transformer(Base):
         # degrees to radians
         if not self.is_pipeline and not radians\
                 and self._input_radians[pj_direction]:
-            for iii in prange(npts, nogil=True):
+            for iii in range(npts):
                 jjj = stride * iii
                 coords[jjj] *= _DG2RAD
                 coords[jjj + 1] *= _DG2RAD
@@ -359,7 +358,7 @@ cdef class _Transformer(Base):
         elif not self.is_pipeline and radians\
                 and not self._input_radians[pj_direction]\
                 and self.input_geographic:
-            for iii in prange(npts, nogil=True):
+            for iii in range(npts):
                 jjj = stride * iii
                 coords[jjj] *= _RAD2DG
                 coords[jjj + 1] *= _RAD2DG
@@ -405,7 +404,7 @@ cdef class _Transformer(Base):
         # radians to degrees
         if not self.is_pipeline and not radians\
                 and self._output_radians[pj_direction]:
-            for iii in prange(npts, nogil=True):
+            for iii in range(npts):
                 jjj = stride * iii
                 coords[jjj] *= _RAD2DG
                 coords[jjj + 1] *= _RAD2DG
@@ -413,7 +412,7 @@ cdef class _Transformer(Base):
         elif not self.is_pipeline and radians\
                 and not self._output_radians[pj_direction]\
                 and self.output_geographic:
-            for iii in prange(npts, nogil=True):
+            for iii in range(npts):
                 jjj = stride * iii
                 coords[jjj] *= _DG2RAD
                 coords[jjj + 1] *= _DG2RAD

--- a/pyproj/proj.pxi
+++ b/pyproj/proj.pxi
@@ -5,7 +5,7 @@ cdef extern from "proj.h":
         PROJ_VERSION_MINOR
         PROJ_VERSION_PATCH
     void proj_context_set_search_paths(
-        PJ_CONTEXT *ctx, int count_paths, const char* const* paths) nogil
+        PJ_CONTEXT *ctx, int count_paths, const char* const* paths)
 
     cdef struct PJ_INFO:
         int         major
@@ -17,14 +17,14 @@ cdef extern from "proj.h":
         const char * const *paths
         size_t path_count
 
-    PJ_INFO proj_info() nogil
+    PJ_INFO proj_info()
 
     # projCtx has been replaced by PJ_CONTEXT *.
     # projPJ  has been replaced by PJ *
     ctypedef struct PJ
     ctypedef struct PJ_CONTEXT
-    PJ_CONTEXT *proj_context_create () nogil
-    PJ_CONTEXT *proj_context_destroy (PJ_CONTEXT *ctx) nogil
+    PJ_CONTEXT *proj_context_create ()
+    PJ_CONTEXT *proj_context_destroy (PJ_CONTEXT *ctx)
 
     ctypedef enum PJ_LOG_LEVEL:
         PJ_LOG_NONE  = 0
@@ -35,13 +35,13 @@ cdef extern from "proj.h":
     ctypedef void (*PJ_LOG_FUNCTION)(void *, int, const char *)
     void proj_log_func (PJ_CONTEXT *ctx, void *app_data, PJ_LOG_FUNCTION logf)
 
-    int proj_errno (const PJ *P) nogil
-    int proj_context_errno (PJ_CONTEXT *ctx) nogil
-    const char * proj_errno_string (int err) nogil
-    int  proj_errno_reset (const PJ *P) nogil
-    PJ *proj_create (PJ_CONTEXT *ctx, const char *definition) nogil
-    PJ *proj_clone(PJ_CONTEXT *ctx, const PJ *obj) nogil
-    PJ *proj_normalize_for_visualization(PJ_CONTEXT *ctx, const PJ* obj) nogil
+    int proj_errno (const PJ *P)
+    int proj_context_errno (PJ_CONTEXT *ctx)
+    const char * proj_errno_string (int err)
+    int  proj_errno_reset (const PJ *P)
+    PJ *proj_create (PJ_CONTEXT *ctx, const char *definition)
+    PJ *proj_clone(PJ_CONTEXT *ctx, const PJ *obj)
+    PJ *proj_normalize_for_visualization(PJ_CONTEXT *ctx, const PJ* obj)
 
     cdef struct PJ_PROJ_INFO:
         const char  *id
@@ -50,7 +50,7 @@ cdef extern from "proj.h":
         int         has_inverse #1 if an inverse mapping exists, 0 otherwise              */
         double      accuracy
 
-    PJ_PROJ_INFO proj_pj_info(PJ *P) nogil
+    PJ_PROJ_INFO proj_pj_info(PJ *P)
 
     ctypedef struct PJ_XYZT:
         double   x,   y,  z, t
@@ -95,16 +95,16 @@ cdef extern from "proj.h":
         PJ_UV uv;
         PJ_LP lp;
 
-    PJ_COORD proj_coord (double x, double y, double z, double t) nogil
+    PJ_COORD proj_coord (double x, double y, double z, double t)
 
     cdef enum PJ_DIRECTION:
         PJ_FWD   =  1 # Forward
         PJ_IDENT =  0 # Do nothing
         PJ_INV   = -1 # Inverse
 
-    int proj_angular_input (PJ *P, PJ_DIRECTION dir) nogil
-    int proj_angular_output (PJ *P, PJ_DIRECTION dir) nogil
-    PJ_COORD proj_trans (PJ *P, PJ_DIRECTION direction, PJ_COORD coord) nogil
+    int proj_angular_input (PJ *P, PJ_DIRECTION dir)
+    int proj_angular_output (PJ *P, PJ_DIRECTION dir)
+    PJ_COORD proj_trans (PJ *P, PJ_DIRECTION direction, PJ_COORD coord)
     size_t proj_trans_generic (
         PJ *P,
         PJ_DIRECTION direction,
@@ -112,9 +112,9 @@ cdef extern from "proj.h":
         double *y, size_t sy, size_t ny,
         double *z, size_t sz, size_t nz,
         double *t, size_t st, size_t nt
-    ) nogil
+    )
     ctypedef struct PJ_AREA
-    PJ *proj_create_crs_to_crs(PJ_CONTEXT *ctx, const char *source_crs, const char *target_crs, PJ_AREA *area) nogil
+    PJ *proj_create_crs_to_crs(PJ_CONTEXT *ctx, const char *source_crs, const char *target_crs, PJ_AREA *area)
 
     cdef enum PJ_COMPARISON_CRITERION:
         PJ_COMP_STRICT
@@ -123,17 +123,17 @@ cdef extern from "proj.h":
 
     void proj_destroy(PJ *obj)
     int proj_is_equivalent_to(const PJ *obj, const PJ* other,
-                              PJ_COMPARISON_CRITERION criterion) nogil
+                              PJ_COMPARISON_CRITERION criterion)
 
-    const char* proj_get_id_auth_name(const PJ *obj, int index) nogil
-    const char* proj_get_id_code(const PJ *obj, int index) nogil
+    const char* proj_get_id_auth_name(const PJ *obj, int index)
+    const char* proj_get_id_code(const PJ *obj, int index)
     int proj_get_area_of_use(PJ_CONTEXT *ctx,
                              const PJ *obj,
                              double* out_west_lon_degree,
                              double* out_south_lat_degree,
                              double* out_east_lon_degree,
                              double* out_north_lat_degree,
-                             const char **out_area_name) nogil
+                             const char **out_area_name)
 
     ctypedef enum PJ_WKT_TYPE:
         PJ_WKT2_2015
@@ -145,7 +145,7 @@ cdef extern from "proj.h":
 
     const char* proj_as_wkt(PJ_CONTEXT *ctx,
                             const PJ *obj, PJ_WKT_TYPE type,
-                            const char* const *options) nogil
+                            const char* const *options)
 
     ctypedef enum PJ_PROJ_STRING_TYPE:
         PJ_PROJ_5
@@ -154,8 +154,8 @@ cdef extern from "proj.h":
     const char* proj_as_proj_string(PJ_CONTEXT *ctx,
                                     const PJ *obj,
                                     PJ_PROJ_STRING_TYPE type,
-                                    const char* const *options) nogil
-    PJ *proj_crs_get_geodetic_crs(PJ_CONTEXT *ctx, const PJ *crs) nogil
+                                    const char* const *options)
+    PJ *proj_crs_get_geodetic_crs(PJ_CONTEXT *ctx, const PJ *crs)
 
     ctypedef enum PJ_TYPE:
         PJ_TYPE_UNKNOWN
@@ -184,12 +184,12 @@ cdef extern from "proj.h":
         PJ_TYPE_CONCATENATED_OPERATION
         PJ_TYPE_OTHER_COORDINATE_OPERATION
 
-    PJ_TYPE proj_get_type(const PJ *obj) nogil
-    const char * proj_get_name(const PJ *obj) nogil
+    PJ_TYPE proj_get_type(const PJ *obj)
+    const char * proj_get_name(const PJ *obj)
 
-    int proj_is_crs(const PJ *obj) nogil
-    PJ *proj_crs_get_datum(PJ_CONTEXT *ctx, const PJ *crs) nogil
-    PJ *proj_crs_get_horizontal_datum(PJ_CONTEXT *ctx, const PJ *crs) nogil
+    int proj_is_crs(const PJ *obj)
+    PJ *proj_crs_get_datum(PJ_CONTEXT *ctx, const PJ *crs)
+    PJ *proj_crs_get_horizontal_datum(PJ_CONTEXT *ctx, const PJ *crs)
 
     ctypedef enum PJ_COORDINATE_SYSTEM_TYPE:
         PJ_CS_TYPE_UNKNOWN
@@ -203,11 +203,11 @@ cdef extern from "proj.h":
         PJ_CS_TYPE_TEMPORALCOUNT
         PJ_CS_TYPE_TEMPORALMEASURE
 
-    PJ *proj_crs_get_coordinate_system(PJ_CONTEXT *ctx, const PJ *crs) nogil
+    PJ *proj_crs_get_coordinate_system(PJ_CONTEXT *ctx, const PJ *crs)
     PJ_COORDINATE_SYSTEM_TYPE proj_cs_get_type(PJ_CONTEXT *ctx,
-                                               const PJ *cs) nogil
+                                               const PJ *cs)
     int proj_cs_get_axis_count(PJ_CONTEXT *ctx,
-                               const PJ *cs) nogil
+                               const PJ *cs)
     int proj_cs_get_axis_info(PJ_CONTEXT *ctx,
                               const PJ *cs, int index,
                               const char **out_name,
@@ -216,38 +216,38 @@ cdef extern from "proj.h":
                               double *out_unit_conv_factor,
                               const char **out_unit_name,
                               const char **out_unit_auth_name,
-                              const char **out_unit_code) nogil
+                              const char **out_unit_code)
 
-    PJ *proj_get_ellipsoid(PJ_CONTEXT *ctx, const PJ *obj) nogil
+    PJ *proj_get_ellipsoid(PJ_CONTEXT *ctx, const PJ *obj)
     int proj_ellipsoid_get_parameters(PJ_CONTEXT *ctx,
                                       const PJ *ellipsoid,
                                       double *out_semi_major_metre,
                                       double *out_semi_minor_metre,
                                       int    *out_is_semi_minor_computed,
-                                      double *out_inv_flattening) nogil
-    PJ *proj_get_prime_meridian(PJ_CONTEXT *ctx, const PJ *obj) nogil
+                                      double *out_inv_flattening)
+    PJ *proj_get_prime_meridian(PJ_CONTEXT *ctx, const PJ *obj)
     int proj_prime_meridian_get_parameters(PJ_CONTEXT *ctx,
                                            const PJ *prime_meridian,
                                            double *out_longitude,
                                            double *out_unit_conv_factor,
-                                           const char **out_unit_name) nogil
-    PJ *proj_crs_get_sub_crs(PJ_CONTEXT *ctx, const PJ *crs, int index) nogil
-    PJ *proj_get_source_crs(PJ_CONTEXT *ctx, const PJ *obj) nogil
-    PJ *proj_get_target_crs(PJ_CONTEXT *ctx, const PJ *obj) nogil
+                                           const char **out_unit_name)
+    PJ *proj_crs_get_sub_crs(PJ_CONTEXT *ctx, const PJ *crs, int index)
+    PJ *proj_get_source_crs(PJ_CONTEXT *ctx, const PJ *obj)
+    PJ *proj_get_target_crs(PJ_CONTEXT *ctx, const PJ *obj)
 
     ctypedef struct PJ_OBJ_LIST
     PJ_OBJ_LIST *proj_identify(PJ_CONTEXT *ctx,
                                const PJ* obj,
                                const char *auth_name,
                                const char* const *options,
-                               int **out_confidence) nogil
+                               int **out_confidence)
     PJ *proj_list_get(PJ_CONTEXT *ctx,
                       const PJ_OBJ_LIST *result,
-                      int index) nogil
-    int proj_list_get_count(const PJ_OBJ_LIST *result) nogil
-    void proj_list_destroy(PJ_OBJ_LIST *result) nogil
-    void proj_int_list_destroy(int* list) nogil
-    void proj_context_use_proj4_init_rules(PJ_CONTEXT *ctx, int enable) nogil
+                      int index)
+    int proj_list_get_count(const PJ_OBJ_LIST *result)
+    void proj_list_destroy(PJ_OBJ_LIST *result)
+    void proj_int_list_destroy(int* list)
+    void proj_context_use_proj4_init_rules(PJ_CONTEXT *ctx, int enable)
     ctypedef enum PJ_GUESSED_WKT_DIALECT:
         PJ_GUESSED_WKT2_2018
         PJ_GUESSED_WKT2_2015
@@ -256,56 +256,56 @@ cdef extern from "proj.h":
         PJ_GUESSED_NOT_WKT
 
     PJ_GUESSED_WKT_DIALECT proj_context_guess_wkt_dialect(PJ_CONTEXT *ctx,
-                                                          const char *wkt) nogil
+                                                          const char *wkt)
 
     ctypedef struct PJ_OPERATIONS:
         const char  *id
         PJ          *(*proj)(PJ *)
         const char  * const *descr
 
-    const PJ_OPERATIONS *proj_list_operations() nogil
+    const PJ_OPERATIONS *proj_list_operations()
 
     ctypedef struct PJ_UNITS:
         const char  *id
         const char  *to_meter
         const char  *name
         double      factor
-    const PJ_UNITS *proj_list_units() nogil
-    const PJ_UNITS *proj_list_angular_units() nogil
+    const PJ_UNITS *proj_list_units()
+    const PJ_UNITS *proj_list_angular_units()
 
     ctypedef struct PJ_ELLPS:
         const char  *id   # ellipse keyword name
         const char  *major  # a= value
         const char  *ell  # elliptical parameter
         const char  *name  # comments
-    const PJ_ELLPS *proj_list_ellps() nogil
+    const PJ_ELLPS *proj_list_ellps()
 
     ctypedef struct PJ_PRIME_MERIDIANS:
         const char  *id
         const char  *defn
-    const PJ_PRIME_MERIDIANS *proj_list_prime_meridians() nogil
+    const PJ_PRIME_MERIDIANS *proj_list_prime_meridians()
 
     PJ *proj_crs_get_coordoperation(PJ_CONTEXT *ctx,
-                                    const PJ *crs) nogil
+                                    const PJ *crs)
 
     int proj_coordoperation_get_method_info(PJ_CONTEXT *ctx,
                                             const PJ *coordoperation,
                                             const char **out_method_name,
                                             const char **out_method_auth_name,
-                                            const char **out_method_code) nogil
+                                            const char **out_method_code)
 
     int proj_coordoperation_is_instantiable(PJ_CONTEXT *ctx,
-                                            const PJ *coordoperation) nogil
+                                            const PJ *coordoperation)
 
     int proj_coordoperation_has_ballpark_transformation(PJ_CONTEXT *ctx,
-                                                        const PJ *coordoperation) nogil
+                                                        const PJ *coordoperation)
 
     int proj_coordoperation_get_param_count(PJ_CONTEXT *ctx,
-                                            const PJ *coordoperation) nogil
+                                            const PJ *coordoperation)
 
     int proj_coordoperation_get_param_index(PJ_CONTEXT *ctx,
                                             const PJ *coordoperation,
-                                            const char *name) nogil
+                                            const char *name)
 
     int proj_coordoperation_get_param(PJ_CONTEXT *ctx,
                                       const PJ *coordoperation,
@@ -319,10 +319,10 @@ cdef extern from "proj.h":
                                       const char **out_unit_name,
                                       const char **out_unit_auth_name,
                                       const char **out_unit_code,
-                                      const char **out_unit_category) nogil
+                                      const char **out_unit_category)
 
     int proj_coordoperation_get_grid_used_count(PJ_CONTEXT *ctx,
-                                                        const PJ *coordoperation) nogil
+                                                        const PJ *coordoperation)
 
     int proj_coordoperation_get_grid_used(PJ_CONTEXT *ctx,
                                           const PJ *coordoperation,
@@ -333,16 +333,16 @@ cdef extern from "proj.h":
                                           const char **out_url,
                                           int *out_direct_download,
                                           int *out_open_license,
-                                          int *out_available) nogil
+                                          int *out_available)
 
     double proj_coordoperation_get_accuracy(PJ_CONTEXT *ctx,
-                                            const PJ *obj) nogil
+                                            const PJ *obj)
 
     int proj_coordoperation_get_towgs84_values(PJ_CONTEXT *ctx,
                                                const PJ *coordoperation,
                                                double *out_values,
                                                int value_count,
-                                               int emit_error_if_incompatible) nogil
+                                               int emit_error_if_incompatible)
 
     ctypedef enum PJ_CATEGORY:
         PJ_CATEGORY_ELLIPSOID,
@@ -355,7 +355,7 @@ cdef extern from "proj.h":
                                   const char *code,
                                   PJ_CATEGORY category,
                                   int usePROJAlternativeGridNames,
-                                  const char* const *options) nogil
+                                  const char* const *options)
 
 
     ctypedef struct PJ_OPERATION_FACTORY_CONTEXT
@@ -363,21 +363,21 @@ cdef extern from "proj.h":
     PJ_OPERATION_FACTORY_CONTEXT *proj_create_operation_factory_context(
         PJ_CONTEXT *ctx,
         const char *authority
-    ) nogil
+    )
     void proj_operation_factory_context_destroy(
         PJ_OPERATION_FACTORY_CONTEXT *ctx
-    ) nogil
+    )
     PJ_OBJ_LIST *proj_create_operations(
         PJ_CONTEXT *ctx,
         const PJ *source_crs,
         const PJ *target_crs,
         const PJ_OPERATION_FACTORY_CONTEXT *operationContext
-    ) nogil
+    )
     void proj_operation_factory_context_set_grid_availability_use(
         PJ_CONTEXT *ctx,
         PJ_OPERATION_FACTORY_CONTEXT *factory_ctx,
         PROJ_GRID_AVAILABILITY_USE use
-    ) nogil
+    )
     void proj_operation_factory_context_set_spatial_criterion(
         PJ_CONTEXT *ctx,
         PJ_OPERATION_FACTORY_CONTEXT *factory_ctx,

--- a/setup.py
+++ b/setup.py
@@ -146,11 +146,6 @@ def get_extension_modules():
         runtime_library_dirs=library_dirs if os.name != "nt" else None,
         libraries=get_libraries(library_dirs),
     )
-    pyproj_omp_arg = os.environ.get("PYPROJ_OMP")
-    if pyproj_omp_arg is not None:
-        ext_options.update(
-            extra_compile_args=[pyproj_omp_arg], extra_link_args=[pyproj_omp_arg]
-        )
     # setup cythonized modules
     return cythonize(
         [


### PR DESCRIPTION
Currently not possible. Only one thread can use one PJ* at a time. https://github.com/OSGeo/PROJ/blob/f567ee4b8739505716cbb000093d78678a97b170/src/iso19111/c_api.cpp#L338

It was unstable. See #380