### PR TITLE
made init= syntax use DeprecationWarning instead of FutureWarning

### DIFF
--- a/pyproj/crs.py
+++ b/pyproj/crs.py
@@ -111,7 +111,7 @@ def _prepare_from_string(in_crs_string):
             warnings.warn(
                 "'+init=<authority>:<code>' syntax is deprecated."
                 " '<authority>:<code>' is the preferred initialization method.",
-                FutureWarning,
+                DeprecationWarning,
             )
     return in_crs_string
 

--- a/test/test_crs.py
+++ b/test/test_crs.py
@@ -56,7 +56,7 @@ def test_from_string():
     assert wgs84_crs.to_proj4() == "+proj=longlat +datum=WGS84 +no_defs +type=crs"
     # Make sure this doesn't get handled using the from_epsg()
     # even though 'epsg' is in the string
-    with pytest.warns(FutureWarning):
+    with pytest.warns(DeprecationWarning):
         epsg_init_crs = CRS.from_string("+init=epsg:26911 +units=m +no_defs=True")
     assert (
         epsg_init_crs.to_proj4()
@@ -152,7 +152,7 @@ def test_empty_json():
 
 
 def test_has_wkt_property():
-    with pytest.warns(FutureWarning):
+    with pytest.warns(DeprecationWarning):
         assert (
             CRS({"init": "EPSG:4326"})
             .to_wkt("WKT1_GDAL")
@@ -167,7 +167,7 @@ def test_to_wkt_pretty():
 
 
 def test_repr():
-    with pytest.warns(FutureWarning):
+    with pytest.warns(DeprecationWarning):
         assert repr(CRS({"init": "EPSG:4326"})) == (
             "<Geographic 2D CRS: +init=epsg:4326 +type=crs>\n"
             "Name: WGS 84\n"
@@ -184,7 +184,7 @@ def test_repr():
 
 
 def test_repr__long():
-    with pytest.warns(FutureWarning):
+    with pytest.warns(DeprecationWarning):
         assert repr(CRS(CRS({"init": "EPSG:4326"}).to_wkt())) == (
             '<Geographic 2D CRS: GEOGCRS["WGS 84",'
             'DATUM["World Geodetic System 1984 ...>\n'
@@ -262,12 +262,12 @@ def test_repr_compound():
 
 
 def test_dunder_str():
-    with pytest.warns(FutureWarning):
+    with pytest.warns(DeprecationWarning):
         assert str(CRS({"init": "EPSG:4326"})) == CRS({"init": "EPSG:4326"}).srs
 
 
 def test_epsg():
-    with pytest.warns(FutureWarning):
+    with pytest.warns(DeprecationWarning):
         assert CRS({"init": "EPSG:4326"}).to_epsg(20) == 4326
         assert CRS({"init": "EPSG:4326"}).to_epsg() is None
     assert CRS.from_user_input(4326).to_epsg() == 4326
@@ -317,7 +317,7 @@ def test_epsg__no_code_available():
 def test_crs_OSR_equivalence():
     crs1 = CRS.from_string("+proj=longlat +datum=WGS84 +no_defs")
     crs2 = CRS.from_string("+proj=latlong +datum=WGS84 +no_defs")
-    with pytest.warns(FutureWarning):
+    with pytest.warns(DeprecationWarning):
         crs3 = CRS({"init": "EPSG:4326"})
     assert crs1 == crs2
     # these are not equivalent in proj.4 now as one uses degrees and the othe radians
@@ -803,14 +803,14 @@ def test_is_exact_same_different_type():
 def test_compare_crs_non_crs():
     assert CRS.from_epsg(4326) != 4.2
     assert CRS.from_epsg(4326) == 4326
-    with pytest.warns(FutureWarning):
+    with pytest.warns(DeprecationWarning):
         assert CRS.from_dict({"init": "epsg:4326"}) == {"init": "epsg:4326"}
         assert CRS.from_dict({"init": "epsg:4326"}) != "epsg:4326"
     assert CRS("epsg:4326") == CustomCRS()
 
 
 def test_is_geocentric__bound():
-    with pytest.warns(FutureWarning):
+    with pytest.warns(DeprecationWarning):
         ccs = CRS("+init=epsg:4328 +towgs84=0,0,0")
     assert ccs.is_geocentric
 
@@ -838,7 +838,7 @@ def test_is_engineering():
 
 
 def test_source_crs__bound():
-    with pytest.warns(FutureWarning):
+    with pytest.warns(DeprecationWarning):
         assert CRS("+init=epsg:4328 +towgs84=0,0,0").source_crs.name == "unknown"
 
 
@@ -847,7 +847,7 @@ def test_source_crs__missing():
 
 
 def test_target_crs__bound():
-    with pytest.warns(FutureWarning):
+    with pytest.warns(DeprecationWarning):
         assert CRS("+init=epsg:4328 +towgs84=0,0,0").target_crs.name == "WGS 84"
 
 

--- a/test/test_datum_shift.py
+++ b/test/test_datum_shift.py
@@ -31,7 +31,7 @@ UTM_z = WGS84_z = 52.8  # Ellipsoidical height in meters
 WGS84_PROJ = Proj(proj="latlong", datum="WGS84")
 UTM_33_PROJ = Proj(proj="utm", zone="33")
 with warnings.catch_warnings():
-    warnings.simplefilter("ignore", FutureWarning)
+    warnings.simplefilter("ignore", DeprecationWarning)
     GAUSSSB_PROJ = Proj(
         init="epsg:3004", towgs84="-122.74,-34.27,-22.83,-1.884,-3.400,-3.030,-15.62"
     )

--- a/test/test_proj.py
+++ b/test/test_proj.py
@@ -117,7 +117,7 @@ class TypeError_Transform_Issue8_Test(unittest.TestCase):
     # https://github.com/jswhit/pyproj/issues/8
 
     def setUp(self):
-        with pytest.warns(FutureWarning):
+        with pytest.warns(DeprecationWarning):
             self.p = Proj(init="epsg:4269")
 
     def test_tranform_none_1st_parmeter(self):

--- a/test/test_transformer.py
+++ b/test/test_transformer.py
@@ -21,7 +21,7 @@ def test_tranform_wgs84_to_custom():
 
 
 def test_transform_wgs84_to_alaska():
-    with pytest.warns(FutureWarning):
+    with pytest.warns(DeprecationWarning):
         lat_lon_proj = pyproj.Proj(init="epsg:4326", preserve_units=False)
         alaska_aea_proj = pyproj.Proj(init="epsg:2964", preserve_units=False)
     test = (-179.72638, 49.752533)
@@ -31,7 +31,7 @@ def test_transform_wgs84_to_alaska():
 
 def test_illegal_transformation():
     # issue 202
-    with pytest.warns(FutureWarning):
+    with pytest.warns(DeprecationWarning):
         p1 = pyproj.Proj(init="epsg:4326")
         p2 = pyproj.Proj(init="epsg:3857")
     xx, yy = pyproj.transform(
@@ -47,7 +47,7 @@ def test_illegal_transformation():
 
 def test_lambert_conformal_transform():
     # issue 207
-    with pytest.warns(FutureWarning):
+    with pytest.warns(DeprecationWarning):
         Midelt = pyproj.Proj(init="epsg:26191")
         WGS84 = pyproj.Proj(init="epsg:4326")
 
@@ -81,7 +81,7 @@ def test_equivalent_crs__different():
 
 
 def test_equivalent_proj():
-    with pytest.warns(FutureWarning):
+    with pytest.warns(DeprecationWarning):
         transformer = Transformer.from_proj(
             "+init=epsg:4326", pyproj.Proj(4326).crs.to_proj4(), skip_equivalent=True
         )
@@ -232,14 +232,14 @@ def test_itransform_time_3rd_invalid():
 
 
 def test_transform_no_error():
-    with pytest.warns(FutureWarning):
+    with pytest.warns(DeprecationWarning):
         pj = Proj(init="epsg:4555")
     pjx, pjy = pj(116.366, 39.867)
     transform(pj, Proj(4326), pjx, pjy, radians=True, errcheck=True)
 
 
 def test_itransform_no_error():
-    with pytest.warns(FutureWarning):
+    with pytest.warns(DeprecationWarning):
         pj = Proj(init="epsg:4555")
     pjx, pjy = pj(116.366, 39.867)
     list(itransform(pj, Proj(4326), [(pjx, pjy)], radians=True, errcheck=True))
@@ -247,20 +247,20 @@ def test_itransform_no_error():
 
 def test_transform_no_exception():
     # issue 249
-    with pytest.warns(FutureWarning):
+    with pytest.warns(DeprecationWarning):
         transformer = Transformer.from_proj("+init=epsg:4326", "+init=epsg:27700")
     transformer.transform(1.716073972, 52.658007833, errcheck=True)
     transformer.itransform([(1.716073972, 52.658007833)], errcheck=True)
 
 
 def test_transform__out_of_bounds():
-    with pytest.warns(FutureWarning):
+    with pytest.warns(DeprecationWarning):
         transformer = Transformer.from_proj("+init=epsg:4326", "+init=epsg:27700")
     assert np.all(np.isinf(transformer.transform(100000, 100000, errcheck=True)))
 
 
 def test_transform_radians():
-    with pytest.warns(FutureWarning):
+    with pytest.warns(DeprecationWarning):
         WGS84 = pyproj.Proj("+init=EPSG:4326")
     ECEF = pyproj.Proj(proj="geocent", ellps="WGS84", datum="WGS84")
     assert_almost_equal(
@@ -284,7 +284,7 @@ def test_transform_radians():
 
 
 def test_itransform_radians():
-    with pytest.warns(FutureWarning):
+    with pytest.warns(DeprecationWarning):
         WGS84 = pyproj.Proj("+init=EPSG:4326")
     ECEF = pyproj.Proj(proj="geocent", ellps="WGS84", datum="WGS84")
     assert_almost_equal(
@@ -459,7 +459,7 @@ def test_transformer_group__unavailable():
 
 
 def test_transform_group__missing_best():
-    with pytest.warns(FutureWarning):
+    with pytest.warns(DeprecationWarning):
         lat_lon_proj = pyproj.Proj(init="epsg:4326", preserve_units=False)
         alaska_aea_proj = pyproj.Proj(init="epsg:2964", preserve_units=False)
 


### PR DESCRIPTION
Decided against promoting to FutureWarning at this stage.  Probably make it a FutureWarning around the time of #365 or when a PROJ release with its removal is more imminent.