### PR TITLE
delay checking for pyproj data directory until importing pyproj

### DIFF
--- a/docs/history.rst
+++ b/docs/history.rst
@@ -4,6 +4,7 @@ Change Log
 2.3.1
 ~~~~~
 * Added cleanup for internal PROJ errors (issue #413)
+* Delay checking for pyproj data directory until importing pyproj (issue #415)
 
 2.3.0
 ~~~~~

--- a/pyproj/__init__.py
+++ b/pyproj/__init__.py
@@ -66,6 +66,7 @@ __all__ = [
 ]
 import sys
 
+from pyproj._datadir import PYPROJ_CONTEXT
 from pyproj._list import (  # noqa: F401
     get_angular_units_map,
     get_ellps_map,
@@ -79,6 +80,8 @@ from pyproj.exceptions import ProjError  # noqa: F401
 from pyproj.geod import Geod, geodesic_version_str, pj_ellps  # noqa: F401
 from pyproj.proj import Proj, pj_list, proj_version_str  # noqa: F401
 from pyproj.transformer import Transformer, itransform, transform  # noqa: F401
+
+PYPROJ_CONTEXT.set_search_paths()
 
 
 def test(**kwargs):

--- a/pyproj/_datadir.pxd
+++ b/pyproj/_datadir.pxd
@@ -4,3 +4,4 @@ cdef ContextManager PROJ_CONTEXT
 
 cdef class ContextManager:
     cdef PJ_CONTEXT *context
+    cdef object _set_search_paths

--- a/pyproj/_datadir.pyx
+++ b/pyproj/_datadir.pyx
@@ -25,15 +25,17 @@ cdef class ContextManager:
 
     def __init__(self):
         self.context = proj_context_create()
-        self.set_search_paths()
+        self._set_search_paths = False
         proj_context_use_proj4_init_rules(self.context, 1)
         proj_log_func(self.context, NULL, pyproj_log_function)
 
-    def set_search_paths(self):
+    def set_search_paths(self, reset=False):
         """
         This method sets the search paths
         based on pyproj.datadir.get_data_dir()
         """
+        if self._set_search_paths and not reset:
+            return
         data_dir_list = get_data_dir().split(os.pathsep)
         cdef char **c_data_dir = <char **>malloc(len(data_dir_list) * sizeof(char*))
         try:
@@ -43,6 +45,7 @@ cdef class ContextManager:
             proj_context_set_search_paths(self.context, len(data_dir_list), c_data_dir)
         finally:
             free(c_data_dir)
+        self._set_search_paths = True
 
 
 cdef ContextManager PROJ_CONTEXT = ContextManager()

--- a/pyproj/datadir.py
+++ b/pyproj/datadir.py
@@ -24,7 +24,7 @@ def set_data_dir(proj_data_dir):
     # reset search paths
     from pyproj._datadir import PYPROJ_CONTEXT
 
-    PYPROJ_CONTEXT.set_search_paths()
+    PYPROJ_CONTEXT.set_search_paths(reset=True)
 
 
 def append_data_dir(proj_data_dir):

--- a/test/test_datadir.py
+++ b/test/test_datadir.py
@@ -1,13 +1,13 @@
 import os
 import shutil
 import tempfile
-import unittest
 from contextlib import contextmanager
 
 import pytest
 from mock import patch
 
 from pyproj import CRS
+from pyproj._datadir import ContextManager
 from pyproj.datadir import DataDirError, append_data_dir, get_data_dir, set_data_dir
 
 
@@ -69,6 +69,13 @@ def test_get_data_dir__missing():
         setup_os_mock(os_mock)
         unset_data_dir()
         assert get_data_dir() is None
+
+
+def test_condext_manager_datadir_missing():
+    with proj_env(), pytest.raises(DataDirError), patch(
+        "pyproj._datadir.get_data_dir", side_effect=DataDirError("test")
+    ):
+        ContextManager().set_search_paths()
 
 
 def test_get_data_dir__from_user():


### PR DESCRIPTION
 - [x] Closes #415
 - [x] Tests added
 - [x] Fully documented, including `history.rst` for all changes and `api/*.rst` for new API

I couldn't reproduce the segfault, so this is my best guess.