### PR TITLE
FIX: address issue where PROJ core dumps on proj_create with +init= when global context does not have data directory set

### DIFF
--- a/docs/history.rst
+++ b/docs/history.rst
@@ -5,6 +5,7 @@ Change Log
 ~~~~~
 * Added cleanup for internal PROJ errors (issue #413)
 * Delay checking for pyproj data directory until importing pyproj (issue #415)
+* Address issue where PROJ core dumps on proj_create with +init= when global context does not have data directory set (issue #415 & issue #368)
 
 2.3.0
 ~~~~~

--- a/pyproj/_datadir.pyx
+++ b/pyproj/_datadir.pyx
@@ -13,7 +13,6 @@ cdef void pyproj_log_function(void *user_data, int level, const char *error_msg)
     if level == PJ_LOG_ERROR:
         ProjError.internal_proj_error = pystrdecode(error_msg)
 
-
 cdef class ContextManager:
     def __cinit__(self):
         self.context = NULL
@@ -42,6 +41,7 @@ cdef class ContextManager:
             for iii in range(len(data_dir_list)):
                 b_data_dir = cstrencode(data_dir_list[iii])
                 c_data_dir[iii] = b_data_dir
+            proj_context_set_search_paths(NULL, len(data_dir_list), c_data_dir)
             proj_context_set_search_paths(self.context, len(data_dir_list), c_data_dir)
         finally:
             free(c_data_dir)


### PR DESCRIPTION
 - [x] Closes #415
-  [x] Closes #368 (I hope)
 - [x] Fully documented, including `history.rst` for all changes and `api/*.rst` for new API