### PR TITLE
Add checks for unititialized pyproj.crs objects to prevent core dumping

### DIFF
--- a/docs/history.rst
+++ b/docs/history.rst
@@ -6,6 +6,7 @@ Change Log
 * Minimum PROJ version is 6.2.0 (issue #411)
 * Remove global pyproj context (issue #418)
 * Add support for PROJ JSON in `pyproj.crs` objects and `pyproj.Transformer` (pull #432)
+* Add checks for unititialized `pyproj.crs` objects to prevent core dumping (issue #433)
 
 2.3.1
 ~~~~~

--- a/test/test_crs.py
+++ b/test/test_crs.py
@@ -1,6 +1,7 @@
 import pytest
 
 from pyproj import CRS
+from pyproj._crs import CoordinateSystem
 from pyproj.crs import CoordinateOperation, Datum, Ellipsoid, PrimeMeridian
 from pyproj.enums import ProjVersion, WktVersion
 from pyproj.exceptions import CRSError
@@ -880,3 +881,113 @@ def test_to_dict_no_proj4():
 def test_to_dict_from_dict():
     cc = CRS.from_epsg(4326)
     assert CRS.from_dict(cc.to_dict()).name == "unknown"
+
+
+def test_uninitialized_datum():
+    dd = Datum()
+    dd_init = Datum.from_epsg("6326")
+    with pytest.raises(CRSError):
+        dd._set_name()
+    with pytest.raises(CRSError):
+        dd.to_wkt()
+    with pytest.raises(CRSError):
+        dd.to_json()
+    with pytest.raises(CRSError):
+        dd.ellipsoid
+    with pytest.raises(CRSError):
+        dd.prime_meridian
+    with pytest.raises(CRSError):
+        dd == dd_init
+    with pytest.raises(CRSError):
+        dd_init == dd
+    with pytest.raises(CRSError):
+        dd.is_exact_same(dd_init)
+    with pytest.raises(CRSError):
+        dd_init.is_exact_same(dd)
+
+
+def test_uninitialized_coordinate_system():
+    cs = CoordinateSystem()
+    dd_init = Datum.from_epsg("6326")
+    with pytest.raises(CRSError):
+        cs._set_name()
+    with pytest.raises(CRSError):
+        cs.to_wkt()
+    with pytest.raises(CRSError):
+        cs.to_json()
+    with pytest.raises(CRSError):
+        cs == dd_init
+    with pytest.raises(CRSError):
+        dd_init == cs
+    with pytest.raises(CRSError):
+        cs.is_exact_same(dd_init)
+    with pytest.raises(CRSError):
+        dd_init.is_exact_same(cs)
+
+
+def test_uninitialized_ellipsoid():
+    ee = Ellipsoid()
+    ee_init = Ellipsoid.from_string("urn:ogc:def:ellipsoid:EPSG::7001")
+    with pytest.raises(CRSError):
+        ee._set_name()
+    with pytest.raises(CRSError):
+        ee.to_wkt()
+    with pytest.raises(CRSError):
+        ee.to_json()
+    with pytest.raises(CRSError):
+        ee == ee_init
+    with pytest.raises(CRSError):
+        ee_init == ee
+    with pytest.raises(CRSError):
+        ee.is_exact_same(ee_init)
+    with pytest.raises(CRSError):
+        ee_init.is_exact_same(ee)
+    assert ee.semi_major_metre != ee.semi_major_metre
+    assert ee.semi_minor_metre != ee.semi_minor_metre
+    assert ee.inverse_flattening != ee.inverse_flattening
+
+
+def test_uninitialized_prime_meridian():
+    pm = PrimeMeridian()
+    pm_init = PrimeMeridian.from_string("urn:ogc:def:meridian:EPSG::8901")
+    with pytest.raises(CRSError):
+        pm._set_name()
+    with pytest.raises(CRSError):
+        pm.to_wkt()
+    with pytest.raises(CRSError):
+        pm.to_json()
+    with pytest.raises(CRSError):
+        pm == pm_init
+    with pytest.raises(CRSError):
+        pm_init == pm
+    with pytest.raises(CRSError):
+        pm.is_exact_same(pm_init)
+    with pytest.raises(CRSError):
+        pm_init.is_exact_same(pm)
+
+
+def test_uninitialized_coordinate_operation():
+    co = CoordinateOperation()
+    co_init = CoordinateOperation.from_string("urn:ogc:def:coordinateOperation:EPSG::1671")
+    with pytest.raises(CRSError):
+        co._set_name()
+    with pytest.raises(CRSError):
+        co.to_wkt()
+    with pytest.raises(CRSError):
+        co.to_json()
+    with pytest.raises(CRSError):
+        co == co_init
+    with pytest.raises(CRSError):
+        co_init == co
+    with pytest.raises(CRSError):
+        co.is_exact_same(co_init)
+    with pytest.raises(CRSError):
+        co_init.is_exact_same(co)
+    with pytest.raises(CRSError):
+        co.params
+    with pytest.raises(CRSError):
+        co.grids
+    with pytest.raises(CRSError):
+        co.to_proj4()
+    with pytest.raises(CRSError):
+        co.towgs84

--- a/test/test_crs.py
+++ b/test/test_crs.py
@@ -968,7 +968,9 @@ def test_uninitialized_prime_meridian():
 
 def test_uninitialized_coordinate_operation():
     co = CoordinateOperation()
-    co_init = CoordinateOperation.from_string("urn:ogc:def:coordinateOperation:EPSG::1671")
+    co_init = CoordinateOperation.from_string(
+        "urn:ogc:def:coordinateOperation:EPSG::1671"
+    )
     with pytest.raises(CRSError):
         co._set_name()
     with pytest.raises(CRSError):


### PR DESCRIPTION
 - [x] Closes #433
 - [x] Tests added
 - [x] Fully documented, including `history.rst` for all changes and `api/*.rst` for new API