### PR TITLE
Use python3 interpreter.

### DIFF
--- a/test/test__main__.py
+++ b/test/test__main__.py
@@ -4,7 +4,7 @@ import pytest
 
 
 def test_main():
-    output = subprocess.check_output(["python", "-m", "pyproj"]).decode("utf-8")
+    output = subprocess.check_output(["python3", "-m", "pyproj"]).decode("utf-8")
     assert "pyproj version:" in output
     assert "PROJ version:" in output
     assert "-v, --verbose  Show verbose debugging version information." in output
@@ -12,7 +12,7 @@ def test_main():
 
 @pytest.mark.parametrize("option", ["-v", "--verbose"])
 def test_main__verbose(option):
-    output = subprocess.check_output(["python", "-m", "pyproj", option]).decode("utf-8")
+    output = subprocess.check_output(["python3", "-m", "pyproj", option]).decode("utf-8")
     assert "pyproj:" in output
     assert "PROJ:" in output
     assert "data dir" in output


### PR DESCRIPTION
The Debian package build for 2.4~rc0 failed due to test failures as reported in #451 

Fixed by using the `python3` interpreter, per PEP 394.
