### PR TITLE
Only require gil for pyproj_log_function when needed

### DIFF
--- a/docs/history.rst
+++ b/docs/history.rst
@@ -1,6 +1,10 @@
 Change Log
 ==========
 
+2.4.1
+~~~~~
+* Only require gil for `pyproj_log_function` when needed (pull #458)
+
 2.4.0
 ~~~~~
 * Minimum PROJ version is 6.2.0 (issue #411)

--- a/pyproj/_datadir.pyx
+++ b/pyproj/_datadir.pyx
@@ -7,12 +7,13 @@ from pyproj.datadir import get_data_dir
 from pyproj.exceptions import ProjError, DataDirError
 
 
-cdef void pyproj_log_function(void *user_data, int level, const char *error_msg):
+cdef void pyproj_log_function(void *user_data, int level, const char *error_msg) nogil:
     """
     Log function for catching PROJ errors.
     """
     if level == PJ_LOG_ERROR:
-        ProjError.internal_proj_error = pystrdecode(error_msg)
+        with gil:
+            ProjError.internal_proj_error = pystrdecode(error_msg)
 
 
 cdef void set_context_data_dir(PJ_CONTEXT* context) except *:


### PR DESCRIPTION
 - [x] Fully documented, including `history.rst` for all changes and `api/*.rst` for new API