### PR TITLE
Docs

### DIFF
--- a/docs/api/transformer.rst
+++ b/docs/api/transformer.rst
@@ -6,8 +6,8 @@ Transformer
 
 The `pyproj.Transformer` has the capabilities of performing 2D, 3D, and 4D (time)
 transformations. It can do anything that the PROJ command line programs
-`proj <https://proj.org/apps/proj.html>`, `cs2cs <https://proj.org/apps/cs2cs.html>`,
-and `cct <https://proj.org/apps/cct.html>` can do.
+`proj <https://proj.org/apps/proj.html>`__, `cs2cs <https://proj.org/apps/cs2cs.html>`__,
+and `cct <https://proj.org/apps/cct.html>`__ can do.
 This means that it allows translation between any pair of definable coordinate systems,
 including support for datum transformation.
 

--- a/docs/api/transformer.rst
+++ b/docs/api/transformer.rst
@@ -16,7 +16,7 @@ including support for datum transformation.
     CRS's are defined as having the first coordinate component point in a
     northerly direction (See PROJ FAQ on 
     `axis order <https://proj.org/faq.html#why-is-the-axis-ordering-in-proj-not-consistent>`_).
-    You can check the axis order with the `pyproj.CRS` class. If you prefer to
+    You can check the axis order with the :class:`~pyproj.crs.CRS` class. If you prefer to
     keep your axis order as always x,y, you can use the `always_xy` option when
     creating the :class:`~pyproj.transformer.Transformer`.
 

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -244,7 +244,7 @@ and documentation see :class:`~pyproj.crs.CRS`.
 Note that `crs_4326` has the latitude (north) axis first and the `crs_26917`
 has the easting axis first. This means that in the transformation, we will need
 to input the data with latitude first and longitude second. Also, note that the
-second projection is a UTM procection with bounds (-84.0, 23.81, -78.0, 84.0) which
+second projection is a UTM projection with bounds (-84.0, 23.81, -78.0, 84.0) which
 are in the form (min_x, min_y, max_x, max_y), so the transformation input/output should
 be within those bounds for best results.
 

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -5,7 +5,7 @@ Change Log
 ~~~~~
 * Wheels contain PROJ version is 6.2.1 (issue #456)
 * Wheels for Linux x86_64 use manylinux2010 (pyproj4/pyproj-wheels/pull/18)
-* BUG: Fix setting lat_ts for mercator projection in :meth:`~pyproj.CRS.from_cf` and :meth:`~pyproj.CRS.to_cf` (issue #461)
+* BUG: Fix setting lat_ts for mercator projection in :meth:`~pyproj.crs.CRS.from_cf` and :meth:`~pyproj.crs.CRS.to_cf` (issue #461)
 * BUG: latlon -> longlat in `CRS.from_cf()` for o_proj so behavior consistent in PROJ 6.2.0 and 6.2.1 (pull #472)
 * ENH: Add repr for `pyproj.crs.CoordinateOperation` and for `pyproj.transformer.TransformerGroup` (pull #464)
 

--- a/pyproj/crs.py
+++ b/pyproj/crs.py
@@ -167,7 +167,7 @@ class CRS(_CRS):
           - An EPSG integer code [i.e. 4326]
           - A tuple of ("auth_name": "auth_code") [i.e ('epsg', '4326')]
           - An object with a `to_wkt` method.
-          - A :class:`~pyproj.CRS`
+          - A :class:`~pyproj.crs.CRS` class
 
         Example usage:
 
@@ -565,7 +565,7 @@ class CRS(_CRS):
           - An EPSG integer code [i.e. 4326]
           - A tuple of ("auth_name": "auth_code") [i.e ('epsg', '4326')]
           - An object with a `to_wkt` method.
-          - A :class:`~pyproj.CRS`
+          - A :class:`~pyproj.crs.CRS` class
 
         Parameters
         ----------


### PR DESCRIPTION
This PR fixes a few typos/broken links in the docs.

I have changed all the `~pyproj.CRS` to `~pyproj.crs.CRS` in the docs because for some reason sphinx autodoc does not seem to understand the former reference, even though there is a
```python
from pyproj.crs import CRS
```
in `pyproj/__init__.py` (see broken link at the last bullet point [here](https://pyproj4.github.io/pyproj/dev/api/crs.html#pyproj.crs.CRS.__init__) for example).