### PR TITLE
add explicit initialisation for all 4 components of projlonlatlin and…

### DIFF
--- a/pyproj/_proj.pyx
+++ b/pyproj/_proj.pyx
@@ -86,6 +86,14 @@ cdef class Proj:
                         with gil:
                             raise ProjError("projection_undefined")
                     continue
+
+                # init all 4 fields in the the input PJ_COORD variable
+                # before use, otherwise 32-bit pyproj may show strange errors
+                projlonlatin.v[0] = 0.0
+                projlonlatin.v[1] = 0.0
+                projlonlatin.v[2] = 0.0
+                projlonlatin.v[3] = 0.0
+
                 if proj_angular_input(self.projobj, PJ_FWD):
                     projlonlatin.uv.u = _DG2RAD * lonsdata[iii]
                     projlonlatin.uv.v = _DG2RAD * latsdata[iii]
@@ -166,6 +174,14 @@ cdef class Proj:
                         with gil:
                             raise ProjError("projection_undefined")
                     continue
+
+                # init all 4 fields in the the input PJ_COORD variable
+                # before use, otherwise 32-bit pyproj may show strange errors
+                projxyin.v[0] = 0.0
+                projxyin.v[1] = 0.0
+                projxyin.v[2] = 0.0
+                projxyin.v[3] = 0.0
+
                 if proj_angular_input(self.projobj, PJ_INV):
                     projxyin.uv.u = _DG2RAD * xdatab[iii]
                     projxyin.uv.v = _DG2RAD * ydatab[iii]


### PR DESCRIPTION
… projxyin. This fixes the test failures on the 32-bit platform for release 2.4.1

Closes #481 

I found this one by trial and error, and to me it seems this is either an undocumented feature of libproj or just a plain bug. Anyway, for pyproj this solved the test failures that I observed on 32-bit.