### PR TITLE
init all 4 fields in the the input PJ_COORD variable before use

### DIFF
--- a/pyproj/_proj.pyx
+++ b/pyproj/_proj.pyx
@@ -58,7 +58,7 @@ cdef class Proj:
         raised and 1.e30 is returned.
         """
         cdef PJ_COORD projxyout
-        cdef PJ_COORD projlonlatin
+        cdef PJ_COORD projlonlatin = proj_coord(0, 0, 0, float("inf"))
         cdef Py_ssize_t buflenx, bufleny, ndim, iii
         cdef double *lonsdata
         cdef double *latsdata
@@ -134,7 +134,7 @@ cdef class Proj:
         if not self.has_inverse:
             raise ProjError('inverse projection undefined')
 
-        cdef PJ_COORD projxyin
+        cdef PJ_COORD projxyin = proj_coord(0, 0, 0, float("inf"))
         cdef PJ_COORD projlonlatout
         cdef Py_ssize_t buflenx, bufleny, ndim, iii
         cdef void *xdata


### PR DESCRIPTION
otherwise 32-bit pyproj may show strange errors

Closes #481 

I found this one by trial and error, and to me it seems this is either an undocumented feature of libproj or just a plain bug. Anyway, for pyproj this solved the test failures that I observed on 32-bit.

I now updated the pull request to your suggestion to apply proj_coord() outside the loop in the cdef statement. Tested again, and can confirm that this implementation also solves the 32-bit problem.
