### PR TITLE
ENH: Added 'pyproj.crs.CRS.equals' with 'ignore_axis_order' kwarg

### DIFF
--- a/docs/history.rst
+++ b/docs/history.rst
@@ -4,6 +4,7 @@ Change Log
 2.5.0
 ~~~~~
 * Remove deprecated PyObject_AsWriteBuffer (issue #495)
+* ENH: Added :meth:`~pyproj.crs.CRS.equals` with `ignore_axis_order` kwarg (issue #493)
 
 2.4.2
 ~~~~~

--- a/pyproj/_crs.pyx
+++ b/pyproj/_crs.pyx
@@ -2299,3 +2299,33 @@ cdef class _CRS(Base):
         if self.is_bound:
             return self.source_crs.is_geocentric
         return self._type == PJ_TYPE_GEOCENTRIC_CRS
+
+    def _equals(self, _CRS other, bint ignore_axis_order):
+        if ignore_axis_order:
+            # Only to be used with DerivedCRS/ProjectedCRS/GeographicCRS
+            return proj_is_equivalent_to(
+                self.projobj,
+                other.projobj,
+                PJ_COMP_EQUIVALENT_EXCEPT_AXIS_ORDER_GEOGCRS,
+            ) == 1
+        return self._is_equivalent(other)
+
+    def equals(self, other, ignore_axis_order=False):
+        """
+        Check if the projection objects are equivalent.
+
+        Properties
+        ----------
+        other: CRS
+            Check if the other object
+        ignore_axis_order: bool, optional
+            If True, it will compare the CRS class and ignore the axis order.
+            Default is False.
+
+        Returns
+        -------
+        bool
+        """
+        if not isinstance(other, _CRS):
+            return False
+        return self._equals(other, ignore_axis_order=ignore_axis_order)

--- a/pyproj/crs.py
+++ b/pyproj/crs.py
@@ -877,12 +877,56 @@ class CRS(_CRS):
 
         return cls(proj_dict)
 
-    def __eq__(self, other):
+    def is_exact_same(self, other, ignore_axis_order=False):
+        """
+        Check if the CRS objects are the exact same.
+
+        Properties
+        ----------
+        other: Any
+            Check if the other CRS is the exact same to this object.
+            If the other object is not a CRS, it will try to create one.
+            On Failure, it will return False.
+
+        Returns
+        -------
+        bool
+        """
         try:
             other = CRS.from_user_input(other)
         except CRSError:
             return False
-        return super(CRS, self).__eq__(other)
+        return super(CRS, self).is_exact_same(other)
+
+    def equals(self, other, ignore_axis_order=False):
+        """
+
+        .. versionadded:: 2.5.0
+
+        Check if the CRS objects are equivalent.
+
+        Properties
+        ----------
+        other: Any
+            Check if the other object is equivalent to this object.
+            If the other object is not a CRS, it will try to create one.
+            On Failure, it will return False.
+        ignore_axis_order: bool, optional
+            If True, it will compare the CRS class and ignore the axis order.
+            Default is False.
+
+        Returns
+        -------
+        bool
+        """
+        try:
+            other = CRS.from_user_input(other)
+        except CRSError:
+            return False
+        return super(CRS, self).equals(other, ignore_axis_order=ignore_axis_order)
+
+    def __eq__(self, other):
+        return self.equals(other)
 
     def __reduce__(self):
         """special method that allows CRS instance to be pickled"""

--- a/test/test_crs.py
+++ b/test/test_crs.py
@@ -1,7 +1,6 @@
 from distutils.version import LooseVersion
 
 import pytest
-
 from pyproj import CRS, Transformer, proj_version_str
 from pyproj._crs import CoordinateSystem
 from pyproj.crs import CoordinateOperation, Datum, Ellipsoid, PrimeMeridian
@@ -789,6 +788,12 @@ def test_crs_init_user_input():
     assert CRS(CRS(4326)).is_exact_same(CRS(CustomCRS()))
 
 
+def test_crs_is_exact_same__non_crs_input():
+    assert CRS(4326).is_exact_same("epsg:4326")
+    with pytest.warns(FutureWarning):
+        assert not CRS(4326).is_exact_same("+init=epsg:4326")
+
+
 def test_to_string__no_auth():
     proj = CRS("+proj=latlong +ellps=GRS80 +towgs84=-199.87,74.79,246.62")
     assert (
@@ -964,3 +969,11 @@ def test_operations__scope_remarks():
     assert [op.remarks for op in transformer.operations] == [
         op.remarks for op in coord_op.operations
     ]
+
+
+def test_crs_equals():
+    assert CRS(4326).equals("epsg:4326")
+
+def test_crs_equals__ignore_axis_order():
+    with pytest.warns(FutureWarning):
+        assert CRS("epsg:4326").equals("+init=epsg:4326", ignore_axis_order=True)

--- a/test/test_crs.py
+++ b/test/test_crs.py
@@ -974,6 +974,7 @@ def test_operations__scope_remarks():
 def test_crs_equals():
     assert CRS(4326).equals("epsg:4326")
 
+
 def test_crs_equals__ignore_axis_order():
     with pytest.warns(FutureWarning):
         assert CRS("epsg:4326").equals("+init=epsg:4326", ignore_axis_order=True)

--- a/test/test_crs.py
+++ b/test/test_crs.py
@@ -1,6 +1,7 @@
 from distutils.version import LooseVersion
 
 import pytest
+
 from pyproj import CRS, Transformer, proj_version_str
 from pyproj._crs import CoordinateSystem
 from pyproj.crs import CoordinateOperation, Datum, Ellipsoid, PrimeMeridian


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Closes #493
 - [x] Tests added
 - [x] Fully documented, including `history.rst` for all changes and `api/*.rst` for new API


This is a potential concept for the ignore axis order feature. The other option could be to add a `method` kwarg with the `exact`, `equvalent`, and `ignore_axis_order` options.