### PR TITLE
added from_json, from_json_dict, and from_string methods to CoordinateSystem added CoordinateSystem to pyproj.crs namespace

### DIFF
--- a/docs/api/crs.rst
+++ b/docs/api/crs.rst
@@ -32,7 +32,7 @@ Area Of Use
 Coordinate System
 -----------------
 
-.. autoclass:: pyproj._crs.CoordinateSystem
+.. autoclass:: pyproj.crs.CoordinateSystem
     :members:
     :inherited-members:
 

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -5,6 +5,8 @@ Change Log
 ~~~~~
 * Remove deprecated PyObject_AsWriteBuffer (issue #495)
 * ENH: Added :meth:`~pyproj.crs.CRS.equals` with `ignore_axis_order` kwarg (issue #493)
+* ENH: Added :meth:`~pyproj.crs.CoordinateSystem.from_json`, :meth:`~pyproj.crs.CoordinateSystem.from_json_dict`, and :meth:`~pyproj.crs.CoordinateSystem.from_string` (pull #501)
+* ENH: Added :class:`~pyproj.crs.CoordinateSystem` to `pyproj.crs` namespace (issue #501)
 
 2.4.2
 ~~~~~

--- a/pyproj/_crs.pyx
+++ b/pyproj/_crs.pyx
@@ -559,7 +559,7 @@ cdef class CoordinateSystem(Base):
         if coordinate_system_pj == NULL or proj_cs_get_type(
             context,
             coordinate_system_pj,
-        ) not in _COORD_SYSTEM_TYPE_MAP:
+        ) == PJ_CS_TYPE_UNKNOWN:
             proj_destroy(coordinate_system_pj)
             proj_context_destroy(context)
             raise CRSError(

--- a/pyproj/crs.py
+++ b/pyproj/crs.py
@@ -22,6 +22,7 @@ CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 __all__ = [
     "CRS",
     "CoordinateOperation",
+    "CoordinateSystem",
     "Datum",
     "Ellipsoid",
     "PrimeMeridian",
@@ -36,6 +37,7 @@ import warnings
 from pyproj._crs import (  # noqa
     _CRS,
     CoordinateOperation,
+    CoordinateSystem,
     Datum,
     Ellipsoid,
     PrimeMeridian,

--- a/test/test_crs.py
+++ b/test/test_crs.py
@@ -725,6 +725,27 @@ def test_coordinate_operation__from_string__invalid():
         CoordinateOperation.from_string("urn:ogc:def:datum:EPSG::6326")
 
 
+def test_coordinate_system__from_string():
+    cs = CoordinateSystem.from_string(
+        '{"$schema":"https://proj.org/schemas/v0.2/projjson.schema.json",'
+        '"type":"CoordinateSystem","subtype":"ellipsoidal",'
+        '"axis":[{"name":"Geodetic latitude","abbreviation":"Lat",'
+        '"direction":"north","unit":"degree"},'
+        '{"name":"Geodetic longitude","abbreviation":"Lon",'
+        '"direction":"east","unit":"degree"}],'
+        '"id":{"authority":"EPSG","code":6422}}'
+    )
+    assert cs.name == "ellipsoidal"
+
+
+@pytest.mark.parametrize(
+    "invalid_cs_string", ["3-598y5-98y", "urn:ogc:def:datum:EPSG::6326"]
+)
+def test_coordinate_system__from_string__invalid(invalid_cs_string):
+    with pytest.raises(CRSError, match="Invalid coordinate system string"):
+        CoordinateSystem.from_string(invalid_cs_string)
+
+
 def test_to_proj4_enum__invalid():
     crs = CRS.from_epsg(4326)
     with pytest.raises(ValueError, match="Invalid value"), pytest.warns(UserWarning):

--- a/test/test_crs_json.py
+++ b/test/test_crs_json.py
@@ -1,6 +1,13 @@
 import pytest
 
-from pyproj.crs import CRS, CoordinateOperation, Datum, Ellipsoid, PrimeMeridian
+from pyproj.crs import (
+    CRS,
+    CoordinateOperation,
+    CoordinateSystem,
+    Datum,
+    Ellipsoid,
+    PrimeMeridian,
+)
 
 
 def test_crs_to_json_dict():
@@ -98,7 +105,6 @@ def test_properties_to_json__pretty__indentation(property_name, expected_type):
         ("datum", "GeodeticReferenceFrame"),
         ("ellipsoid", "Ellipsoid"),
         ("prime_meridian", "PrimeMeridian"),
-        ("coordinate_system", "CoordinateSystem"),
     ],
 )
 def test_properties_to_json_dict(property_name, expected_type):
@@ -120,15 +126,15 @@ def test_properties_from_json_dict(property_name, init_class):
     assert init_class.from_json_dict(prop.to_json_dict()) == prop
 
 
-@pytest.mark.parametrize(
-    "property_name, init_class",
-    [
-        ("coordinate_operation", CoordinateOperation),
-        ("datum", Datum),
-        ("ellipsoid", Ellipsoid),
-        ("prime_meridian", PrimeMeridian),
-    ],
-)
-def test_properties_from_json(property_name, init_class):
-    prop = getattr(CRS.from_epsg(26915), property_name)
-    assert init_class.from_json(prop.to_json()) == prop
+def test_coordinate_system_from_json_dict():
+    # separate test from other properties due to
+    # https://github.com/OSGeo/PROJ/issues/1818
+    aeqd_cs = CRS(proj="aeqd", lon_0=-80, lat_0=40.5).coordinate_system
+    assert CoordinateSystem.from_json_dict(aeqd_cs.to_json_dict()) == aeqd_cs
+
+
+def test_coordinate_system_from_json():
+    # separate test from other properties due to
+    # https://github.com/OSGeo/PROJ/issues/1818
+    aeqd_cs = CRS(proj="aeqd", lon_0=-80, lat_0=40.5).coordinate_system
+    assert CoordinateSystem.from_json(aeqd_cs.to_json()) == aeqd_cs


### PR DESCRIPTION
 - [x] Tests added
 - [x] Fully documented, including `history.rst` for all changes and `api/*.rst` for new API

Currently some roundtrips using `to_json/from_json` won't work: https://github.com/OSGeo/PROJ/issues/1818

Also, support for the WKT form is missing: https://github.com/OSGeo/PROJ/issues/1819