### PR TITLE
ENH: Added EquidistantCylindricalConversion(and PlateCaree alias) and LambertCylindricalEqualAreaScaleConversion

### DIFF
--- a/docs/api/crs/coordinate_operation.rst
+++ b/docs/api/crs/coordinate_operation.rst
@@ -41,6 +41,14 @@ AzumuthalEquidistantConversion
     :special-members: __new__
 
 
+EquidistantCylindricalConversion
+--------------------------------
+.. autoclass:: pyproj.crs.coordinate_operation.EquidistantCylindricalConversion
+    :members:
+    :show-inheritance:
+    :special-members: __new__
+
+
 GeostationarySatelliteConversion
 --------------------------------
 
@@ -84,6 +92,12 @@ LambertCylindricalEqualAreaConversion
     :show-inheritance:
     :special-members: __new__
 
+.. autoclass:: pyproj.crs.coordinate_operation.LambertCylindricalEqualAreaScaleConversion
+
+    :members:
+    :show-inheritance:
+    :special-members: __new__
+
 
 MercatorAConversion
 --------------------
@@ -115,6 +129,14 @@ OrthographicConversion
 -----------------------
 
 .. autoclass:: pyproj.crs.coordinate_operation.OrthographicConversion
+    :members:
+    :show-inheritance:
+    :special-members: __new__
+
+
+PlateCareeConversion
+--------------------------------
+.. autoclass:: pyproj.crs.coordinate_operation.PlateCareeConversion
     :members:
     :show-inheritance:
     :special-members: __new__

--- a/pyproj/crs/coordinate_operation.py
+++ b/pyproj/crs/coordinate_operation.py
@@ -581,8 +581,7 @@ class LambertCylindricalEqualAreaScaleConversion(CoordinateOperation):
             "+lon_0={longitude_natural_origin} "
             "+x_0={false_easting} "
             "+y_0={false_northing} "
-            "+k_0={scale_factor_natural_origin}"
-            .format(
+            "+k_0={scale_factor_natural_origin}".format(
                 longitude_natural_origin=longitude_natural_origin,
                 false_easting=false_easting,
                 false_northing=false_northing,
@@ -1332,6 +1331,7 @@ class EquidistantCylindricalConversion(CoordinateOperation):
 
     https://proj.org/operations/projections/eqc.html
     """
+
     def __new__(
         cls,
         latitude_first_parallel=0.0,

--- a/pyproj/crs/coordinate_operation.py
+++ b/pyproj/crs/coordinate_operation.py
@@ -539,6 +539,58 @@ class LambertCylindricalEqualAreaConversion(CoordinateOperation):
         return cls.from_json_dict(cea_json)
 
 
+class LambertCylindricalEqualAreaScaleConversion(CoordinateOperation):
+    """
+    .. versionadded:: 2.5.0
+
+    Class for constructing the Lambert Cylindrical Equal Area conversion.
+
+    This version uses the scale factor and differs from the official version.
+
+    The scale factor will be converted to the Latitude of 1st standard parallel (lat_ts)
+    when exporting to WKT in PROJ>=7.0.0. Previous version will export it as a
+    PROJ-based coordinate operation in the WKT.
+
+    https://proj.org/operations/projections/cea.html
+    """
+
+    def __new__(
+        cls,
+        longitude_natural_origin=0.0,
+        false_easting=0.0,
+        false_northing=0.0,
+        scale_factor_natural_origin=1.0,
+    ):
+        """
+        Parameters
+        ----------
+        longitude_natural_origin: float, optional
+            Longitude of projection center (lon_0). Defaults to 0.0.
+        false_easting: float, optional
+            False easting (x_0). Defaults to 0.0.
+        false_northing: float, optional
+            False northing (y_0). Defaults to 0.0.
+        scale_factor_natural_origin: float, optional
+            Scale factor at natural origin (k or k_0). Defaults to 1.0
+
+        """
+        # hack due to: https://github.com/OSGeo/PROJ/issues/1881
+        # https://proj.org/operations/projections/cea.html
+        return cls.from_string(
+            "+proj=cea "
+            "+lon_0={longitude_natural_origin} "
+            "+x_0={false_easting} "
+            "+y_0={false_northing} "
+            "+k_0={scale_factor_natural_origin}"
+            .format(
+                longitude_natural_origin=longitude_natural_origin,
+                false_easting=false_easting,
+                false_northing=false_northing,
+                scale_factor_natural_origin=scale_factor_natural_origin,
+            )
+        )
+
+
 class MercatorAConversion(CoordinateOperation):
     """
     .. versionadded:: 2.5.0
@@ -1270,6 +1322,84 @@ class RotatedLatitudeLongitudeConversion(CoordinateOperation):
             ],
         }
         return cls.from_json_dict(rot_latlon_json)
+
+
+class EquidistantCylindricalConversion(CoordinateOperation):
+    """
+    .. versionadded:: 2.5.0
+
+    Class for constructing the Equidistant Cylintrical (Plate Carrée) conversion.
+
+    https://proj.org/operations/projections/eqc.html
+    """
+    def __new__(
+        cls,
+        latitude_first_parallel=0.0,
+        latitude_natural_origin=0.0,
+        longitude_natural_origin=0.0,
+        false_easting=0.0,
+        false_northing=0.0,
+    ):
+        """
+        Parameters
+        ----------
+        latitude_first_parallel: float, optional
+            Latitude of 1st standard parallel (lat_ts). Defaults to 0.0.
+        latitude_natural_origin: float, optional
+            Longitude of projection center (lon_0). Defaults to 0.0.
+        longitude_natural_origin: float, optional
+            Longitude of projection center (lon_0). Defaults to 0.0.
+        false_easting: float, optional
+            False easting (x_0). Defaults to 0.0.
+        false_northing: float, optional
+            False northing (y_0). Defaults to 0.0.
+        """
+        eqc_json = {
+            "$schema": "https://proj.org/schemas/v0.2/projjson.schema.json",
+            "type": "Conversion",
+            "name": "unknown",
+            "method": {
+                "name": "Equidistant Cylindrical",
+                "id": {"authority": "EPSG", "code": 1028},
+            },
+            "parameters": [
+                {
+                    "name": "Latitude of 1st standard parallel",
+                    "value": latitude_first_parallel,
+                    "unit": "degree",
+                    "id": {"authority": "EPSG", "code": 8823},
+                },
+                {
+                    "name": "Latitude of natural origin",
+                    "value": latitude_natural_origin,
+                    "unit": "degree",
+                    "id": {"authority": "EPSG", "code": 8801},
+                },
+                {
+                    "name": "Longitude of natural origin",
+                    "value": longitude_natural_origin,
+                    "unit": "degree",
+                    "id": {"authority": "EPSG", "code": 8802},
+                },
+                {
+                    "name": "False easting",
+                    "value": false_easting,
+                    "unit": "metre",
+                    "id": {"authority": "EPSG", "code": 8806},
+                },
+                {
+                    "name": "False northing",
+                    "value": false_northing,
+                    "unit": "metre",
+                    "id": {"authority": "EPSG", "code": 8807},
+                },
+            ],
+        }
+        return cls.from_json_dict(eqc_json)
+
+
+# Add an alias for PlateCaree
+PlateCareeConversion = EquidistantCylindricalConversion
 
 
 class ToWGS84Transformation(CoordinateOperation):

--- a/test/crs/test_crs_coordinate_operation.py
+++ b/test/crs/test_crs_coordinate_operation.py
@@ -4,15 +4,18 @@ from pyproj.crs import GeographicCRS
 from pyproj.crs.coordinate_operation import (
     AlbersEqualAreaConversion,
     AzumuthalEquidistantConversion,
+    EquidistantCylindricalConversion,
     GeostationarySatelliteConversion,
     HotineObliqueMercatorBConversion,
     LambertAzumuthalEqualAreaConversion,
     LambertConformalConic1SPConversion,
     LambertConformalConic2SPConversion,
     LambertCylindricalEqualAreaConversion,
+    LambertCylindricalEqualAreaScaleConversion,
     MercatorAConversion,
     MercatorBConversion,
     OrthographicConversion,
+    PlateCareeConversion,
     PolarStereographicAConversion,
     PolarStereographicBConversion,
     RotatedLatitudeLongitudeConversion,
@@ -221,7 +224,7 @@ def test_lambert_conformat_conic_1sp_operation():
         longitude_natural_origin=2,
         false_easting=3,
         false_northing=4,
-        scale_factor_natural_origin=5,
+        scale_factor_natural_origin=0.5,
     )
     assert aeaop.name == "unknown"
     assert aeaop.method_name == "Lambert Conic Conformal (1SP)"
@@ -230,7 +233,7 @@ def test_lambert_conformat_conic_1sp_operation():
         "Longitude of natural origin": 2.0,
         "False easting": 3.0,
         "False northing": 4.0,
-        "Scale factor at natural origin": 5.0,
+        "Scale factor at natural origin": 0.5,
     }
 
 
@@ -282,7 +285,7 @@ def test_mercator_a_operation():
         longitude_natural_origin=2,
         false_easting=3,
         false_northing=4,
-        scale_factor_natural_origin=5,
+        scale_factor_natural_origin=0.5,
     )
     assert aeaop.name == "unknown"
     assert aeaop.method_name == "Mercator (variant A)"
@@ -291,7 +294,7 @@ def test_mercator_a_operation():
         "Longitude of natural origin": 2.0,
         "False easting": 3.0,
         "False northing": 4.0,
-        "Scale factor at natural origin": 5.0,
+        "Scale factor at natural origin": 0.5,
     }
 
 
@@ -350,7 +353,7 @@ def test_hotline_oblique_mercator_b_operation():
         longitude_projection_centre=2,
         azimuth_initial_line=3,
         angle_from_rectified_to_skew_grid=4,
-        scale_factor_on_initial_line=5,
+        scale_factor_on_initial_line=0.5,
         easting_projection_centre=6,
         northing_projection_centre=7,
     )
@@ -361,7 +364,7 @@ def test_hotline_oblique_mercator_b_operation():
         "Longitude of projection centre": 2.0,
         "Azimuth of initial line": 3.0,
         "Angle from Rectified to Skew Grid": 4.0,
-        "Scale factor on initial line": 5.0,
+        "Scale factor on initial line": 0.5,
         "Easting at projection centre": 6.0,
         "Northing at projection centre": 7.0,
     }
@@ -415,7 +418,7 @@ def test_polar_stereographic_a_operation():
         longitude_natural_origin=2,
         false_easting=3,
         false_northing=4,
-        scale_factor_natural_origin=5,
+        scale_factor_natural_origin=0.5,
     )
     assert aeaop.name == "unknown"
     assert aeaop.method_name == "Polar Stereographic (variant A)"
@@ -424,7 +427,7 @@ def test_polar_stereographic_a_operation():
         "Longitude of natural origin": 2.0,
         "False easting": 3.0,
         "False northing": 4.0,
-        "Scale factor at natural origin": 5.0,
+        "Scale factor at natural origin": 0.5,
     }
 
 
@@ -512,7 +515,7 @@ def test_transverse_mercator_operation():
         longitude_natural_origin=2,
         false_easting=3,
         false_northing=4,
-        scale_factor_natural_origin=5,
+        scale_factor_natural_origin=0.5,
     )
     assert aeaop.name == "unknown"
     assert aeaop.method_name == "Transverse Mercator"
@@ -521,7 +524,7 @@ def test_transverse_mercator_operation():
         "Longitude of natural origin": 2.0,
         "False easting": 3.0,
         "False northing": 4.0,
-        "Scale factor at natural origin": 5.0,
+        "Scale factor at natural origin": 0.5,
     }
 
 
@@ -578,6 +581,68 @@ def test_rotated_latitude_longitude_operation():
     assert aeaop.name == "unknown"
     assert aeaop.method_name == "PROJ ob_tran o_proj=longlat"
     assert _to_dict(aeaop) == {"o_lat_p": 1.0, "o_lon_p": 2.0, "lon_0": 3.0}
+
+
+def test_lambert_cylindrical_equidistant_scale_operation__defaults():
+    aeaop = LambertCylindricalEqualAreaScaleConversion()
+    assert aeaop.name == "PROJ-based coordinate operation"
+    assert aeaop.method_name == (
+        "PROJ-based operation method: +proj=cea +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k_0=1.0"
+    )
+    assert _to_dict(aeaop) == {}
+
+
+def test_lambert_cylindrical_equidistant_scale_operation():
+    aeaop = LambertCylindricalEqualAreaScaleConversion(
+        longitude_natural_origin=2,
+        false_easting=3,
+        false_northing=4,
+        scale_factor_natural_origin=0.5,
+    )
+    assert aeaop.name == "PROJ-based coordinate operation"
+    assert aeaop.method_name == (
+        "PROJ-based operation method: +proj=cea +lon_0=2 +x_0=3 +y_0=4 +k_0=0.5"
+    )
+    assert _to_dict(aeaop) == {}
+
+
+@pytest.mark.parametrize("eqc_class", [
+    EquidistantCylindricalConversion,
+    PlateCareeConversion,
+])
+def test_equidistant_cylindrical_conversion__defaults(eqc_class):
+    eqc = eqc_class()
+    assert eqc.name == "unknown"
+    assert eqc.method_name == "Equidistant Cylindrical"
+    assert _to_dict(eqc) == {
+        "Latitude of 1st standard parallel": 0.0,
+        "Latitude of natural origin": 0.0,
+        "Longitude of natural origin": 0.0,
+        "False easting": 0.0,
+        "False northing": 0.0,
+    }
+
+@pytest.mark.parametrize("eqc_class", [
+    EquidistantCylindricalConversion,
+    PlateCareeConversion,
+])
+def test_equidistant_cylindrical_conversion(eqc_class):
+    eqc = eqc_class(
+        latitude_first_parallel=1.0,
+        latitude_natural_origin=2.0,
+        longitude_natural_origin=3.0,
+        false_easting=4.0,
+        false_northing=5.0,
+    )
+    assert eqc.name == "unknown"
+    assert eqc.method_name == "Equidistant Cylindrical"
+    assert _to_dict(eqc) == {
+        "Latitude of 1st standard parallel": 1.0,
+        "Latitude of natural origin": 2.0,
+        "Longitude of natural origin": 3.0,
+        "False easting": 4.0,
+        "False northing": 5.0,
+    }
 
 
 def test_towgs84_transformation():

--- a/test/crs/test_crs_coordinate_operation.py
+++ b/test/crs/test_crs_coordinate_operation.py
@@ -607,7 +607,7 @@ def test_lambert_cylindrical_equidistant_scale_operation():
 
 
 @pytest.mark.parametrize(
-    "eqc_class", [EquidistantCylindricalConversion, PlateCareeConversion,]
+    "eqc_class", [EquidistantCylindricalConversion, PlateCareeConversion]
 )
 def test_equidistant_cylindrical_conversion__defaults(eqc_class):
     eqc = eqc_class()
@@ -623,7 +623,7 @@ def test_equidistant_cylindrical_conversion__defaults(eqc_class):
 
 
 @pytest.mark.parametrize(
-    "eqc_class", [EquidistantCylindricalConversion, PlateCareeConversion,]
+    "eqc_class", [EquidistantCylindricalConversion, PlateCareeConversion]
 )
 def test_equidistant_cylindrical_conversion(eqc_class):
     eqc = eqc_class(

--- a/test/crs/test_crs_coordinate_operation.py
+++ b/test/crs/test_crs_coordinate_operation.py
@@ -606,10 +606,9 @@ def test_lambert_cylindrical_equidistant_scale_operation():
     assert _to_dict(aeaop) == {}
 
 
-@pytest.mark.parametrize("eqc_class", [
-    EquidistantCylindricalConversion,
-    PlateCareeConversion,
-])
+@pytest.mark.parametrize(
+    "eqc_class", [EquidistantCylindricalConversion, PlateCareeConversion,]
+)
 def test_equidistant_cylindrical_conversion__defaults(eqc_class):
     eqc = eqc_class()
     assert eqc.name == "unknown"
@@ -622,10 +621,10 @@ def test_equidistant_cylindrical_conversion__defaults(eqc_class):
         "False northing": 0.0,
     }
 
-@pytest.mark.parametrize("eqc_class", [
-    EquidistantCylindricalConversion,
-    PlateCareeConversion,
-])
+
+@pytest.mark.parametrize(
+    "eqc_class", [EquidistantCylindricalConversion, PlateCareeConversion,]
+)
 def test_equidistant_cylindrical_conversion(eqc_class):
     eqc = eqc_class(
         latitude_first_parallel=1.0,


### PR DESCRIPTION
 - [x] Tests added
 - [x] Fully documented, including `history.rst` for all changes and `api/*.rst` for new API


Also, added in fix for scale factor in tests since it needs to be between 0-1.