### PR TITLE
ENH: Use CRS to derive coordinate operation for LambertCylindricalEqualAreaScaleConversion in PROJ 7+

### DIFF
--- a/pyproj/crs/coordinate_operation.py
+++ b/pyproj/crs/coordinate_operation.py
@@ -1,3 +1,6 @@
+from distutils.version import LooseVersion
+
+from pyproj import proj_version_str
 from pyproj._crs import CoordinateOperation
 from pyproj.crs import CRS
 from pyproj.exceptions import CRSError
@@ -576,7 +579,7 @@ class LambertCylindricalEqualAreaScaleConversion(CoordinateOperation):
         """
         # hack due to: https://github.com/OSGeo/PROJ/issues/1881
         # https://proj.org/operations/projections/cea.html
-        return cls.from_string(
+        proj_string = (
             "+proj=cea "
             "+lon_0={longitude_natural_origin} "
             "+x_0={false_easting} "
@@ -588,6 +591,9 @@ class LambertCylindricalEqualAreaScaleConversion(CoordinateOperation):
                 scale_factor_natural_origin=scale_factor_natural_origin,
             )
         )
+        if LooseVersion(proj_version_str) >= LooseVersion("7.0.0"):
+            return cls.from_json(CRS(proj_string).coordinate_operation.to_json())
+        return cls.from_string(proj_string)
 
 
 class MercatorAConversion(CoordinateOperation):

--- a/test/crs/test_crs_coordinate_operation.py
+++ b/test/crs/test_crs_coordinate_operation.py
@@ -1,5 +1,9 @@
-import pytest
+from distutils.version import LooseVersion
 
+import pytest
+from numpy.testing import assert_almost_equal
+
+from pyproj import proj_version_str
 from pyproj.crs import GeographicCRS
 from pyproj.crs.coordinate_operation import (
     AlbersEqualAreaConversion,
@@ -616,27 +620,51 @@ def test_rotated_latitude_longitude_operation():
     assert _to_dict(aeaop) == {"o_lat_p": 1.0, "o_lon_p": 2.0, "lon_0": 3.0}
 
 
-def test_lambert_cylindrical_equidistant_scale_operation__defaults():
-    aeaop = LambertCylindricalEqualAreaScaleConversion()
-    assert aeaop.name == "PROJ-based coordinate operation"
-    assert aeaop.method_name == (
-        "PROJ-based operation method: +proj=cea +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k_0=1.0"
-    )
-    assert _to_dict(aeaop) == {}
+def test_lambert_cylindrical_equal_area_scale_operation__defaults():
+    lceaop = LambertCylindricalEqualAreaScaleConversion()
+    if LooseVersion(proj_version_str) >= LooseVersion("7.0.0"):
+        assert lceaop.name == "unknown"
+        assert lceaop.method_name == "Lambert Cylindrical Equal Area"
+        assert _to_dict(lceaop) == {
+            "Latitude of 1st standard parallel": 0.0,
+            "Longitude of natural origin": 0.0,
+            "False easting": 0.0,
+            "False northing": 0.0,
+        }
+    else:
+        assert lceaop.name == "PROJ-based coordinate operation"
+        assert lceaop.method_name == (
+            "PROJ-based operation method: +proj=cea +lon_0=0.0 "
+            "+x_0=0.0 +y_0=0.0 +k_0=1.0"
+        )
+        assert _to_dict(lceaop) == {}
 
 
-def test_lambert_cylindrical_equidistant_scale_operation():
-    aeaop = LambertCylindricalEqualAreaScaleConversion(
+def test_lambert_cylindrical_equal_area_scale_operation():
+    lceaop = LambertCylindricalEqualAreaScaleConversion(
         longitude_natural_origin=2,
         false_easting=3,
         false_northing=4,
-        scale_factor_natural_origin=0.5,
+        scale_factor_natural_origin=0.999,
     )
-    assert aeaop.name == "PROJ-based coordinate operation"
-    assert aeaop.method_name == (
-        "PROJ-based operation method: +proj=cea +lon_0=2 +x_0=3 +y_0=4 +k_0=0.5"
-    )
-    assert _to_dict(aeaop) == {}
+    if LooseVersion(proj_version_str) >= LooseVersion("7.0.0"):
+        assert lceaop.name == "unknown"
+        assert lceaop.method_name == "Lambert Cylindrical Equal Area"
+        op_dict = _to_dict(lceaop)
+        assert_almost_equal(
+            op_dict.pop("Latitude of 1st standard parallel"), 2.57, decimal=2,
+        )
+        assert op_dict == {
+            "Longitude of natural origin": 2.0,
+            "False easting": 3.0,
+            "False northing": 4.0,
+        }
+    else:
+        assert lceaop.name == "PROJ-based coordinate operation"
+        assert lceaop.method_name == (
+            "PROJ-based operation method: +proj=cea +lon_0=2 +x_0=3 +y_0=4 +k_0=0.999"
+        )
+        assert _to_dict(lceaop) == {}
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
 - [x] Tests added
 