### PR TITLE
Remove duplicated lines from docstrings in geod.py

### DIFF
--- a/pyproj/geod.py
+++ b/pyproj/geod.py
@@ -47,8 +47,6 @@ class Geod(_Geod):
     performs forward and inverse geodetic, or Great Circle,
     computations.  The forward computation (using the 'fwd' method)
     involves determining latitude, longitude and back azimuth of a
-    computations.  The forward computation (using the 'fwd' method)
-    involves determining latitude, longitude and back azimuth of a
     terminus point given the latitude and longitude of an initial
     point, plus azimuth and distance. The inverse computation (using
     the 'inv' method) involves determining the forward and back
@@ -201,8 +199,6 @@ class Geod(_Geod):
         """
         forward transformation - Returns longitudes, latitudes and back
         azimuths of terminus points given longitudes (lons) and
-        latitudes (lats) of initial points, plus forward azimuths (az)
-        and distances (dist).
         latitudes (lats) of initial points, plus forward azimuths (az)
         and distances (dist).
 


### PR DESCRIPTION
This PR simply removes what looks like duplicated lines in 2 docstrings of the `pyproj.geod` module.

I've also noticed that three methods of the `Geod` class (namely `fwd`, `inv`, and `npts`) seem to be older than the other methods of the class, and don't have docstrings with properly formatted `Parameters` and `Returns` sections describing the function signatures.
I can update these docstrings if you want!