### PR TITLE
Don't silently ignore kwargs when projparams are specified

### DIFF
--- a/pyproj/proj.py
+++ b/pyproj/proj.py
@@ -95,7 +95,7 @@ class Proj(_Proj):
         Parameters
         ----------
         projparams: int, str, dict, pyproj.CRS
-            A PROJ or WKT string, PROJ dict, EPSG integer, or a pyproj.CRS instnace.
+            A PROJ or WKT string, PROJ dict, EPSG integer, or a pyproj.CRS instance.
         preserve_units: bool
             If false, will ensure +units=m.
         **kwargs:
@@ -143,7 +143,7 @@ class Proj(_Proj):
         >>> '{:.3f} {:.3f}'.format(x2, y2)
         '116.366 39.867'
         """
-        self.crs = CRS.from_user_input(projparams if projparams is not None else kwargs)
+        self.crs = CRS.from_user_input(projparams, **kwargs)
         # make sure units are meters if preserve_units is False.
         if not preserve_units and "foot" in self.crs.axis_info[0].unit_name:
             # ignore export to PROJ string deprecation warning

--- a/test/crs/test_crs.py
+++ b/test/crs/test_crs.py
@@ -77,6 +77,12 @@ def test_from_string():
         )
 
 
+def test_initialize_projparams_with_kwargs():
+    crs_mixed_args = CRS("+proj=utm +zone=10", ellps="WGS84")
+    crs_positional = CRS("+proj=utm +zone=10 +ellps=WGS84")
+    assert crs_mixed_args.is_exact_same(crs_positional)
+
+
 def test_bare_parameters():
     """ Make sure that bare parameters (e.g., no_defs) are handled properly,
     even if they come in with key=True.  This covers interaction with pyproj,

--- a/test/test_proj.py
+++ b/test/test_proj.py
@@ -398,6 +398,12 @@ def test_initialize_proj_crs_no_plus():
     assert proj.crs.srs == "proj=lonlat type=crs"
 
 
+def test_initialize_projparams_with_kwargs():
+    proj_mixed_args = Proj("+proj=utm +zone=10", ellps="WGS84")
+    proj_positional = Proj("+proj=utm +zone=10 +ellps=WGS84")
+    assert proj_mixed_args.is_exact_same(proj_positional)
+
+
 def test_equals_different_type():
     assert Proj("epsg:4326") != ""
 


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Closes #552
 - [x] Tests added
 - [ ] Fully documented, including `history.rst` for all changes and `api/*.rst` for new API
