### PR TITLE
BUG: Allow *_name to be added in CRS.to_cf

### DIFF
--- a/docs/history.rst
+++ b/docs/history.rst
@@ -1,6 +1,10 @@
 Change Log
 ==========
 
+2.6.1
+~~~~~
+* BUG: Allow geographic_crs_name to be added to cf (issue #585)
+
 2.6.0
 ~~~~~
 * ENH: Added :meth:`pyproj.proj.Proj.get_factors` (issue #503)

--- a/pyproj/crs/crs.py
+++ b/pyproj/crs/crs.py
@@ -627,7 +627,7 @@ class CRS(_CRS):
                 cf_dict["prime_meridian_name"] = self.prime_meridian.name
 
         # handle geographic CRS
-        if self.geodetic_crs and self.geodetic_crs.name not in unknown_names:
+        if self.geodetic_crs:
             cf_dict["geographic_crs_name"] = self.geodetic_crs.name
 
         if self.is_geographic:
@@ -700,6 +700,7 @@ class CRS(_CRS):
         -------
         CRS
         """
+        unknown_names = ("unknown", "undefined")
         if "crs_wkt" in in_cf:
             return CRS(in_cf["crs_wkt"])
         elif "spatial_ref" in in_cf:  # for previous supported WKT key
@@ -725,7 +726,7 @@ class CRS(_CRS):
             geographic_crs = GeographicCRS(
                 name=geographic_crs_name or "undefined", datum=datum,
             )  # type: CRS
-        elif geographic_crs_name:
+        elif geographic_crs_name and geographic_crs_name not in unknown_names:
             geographic_crs = CRS(geographic_crs_name)
         else:
             geographic_crs = GeographicCRS()

--- a/pyproj/crs/crs.py
+++ b/pyproj/crs/crs.py
@@ -580,7 +580,6 @@ class CRS(_CRS):
             CF-1.8 version of the projection.
 
         """
-        unknown_names = ("unknown", "undefined")
         cf_dict = {"crs_wkt": self.to_wkt(wkt_version)}  # type: Dict[str, Any]
 
         # handle bound CRS
@@ -608,7 +607,7 @@ class CRS(_CRS):
             vert_json = self.to_json_dict()
             if "geoid_model" in vert_json:
                 cf_dict["geoid_name"] = vert_json["geoid_model"]["name"]
-            if self.datum and self.datum.name not in unknown_names:
+            if self.datum:
                 cf_dict["geopotential_datum_name"] = self.datum.name
             return cf_dict
 
@@ -619,12 +618,10 @@ class CRS(_CRS):
                 semi_minor_axis=self.ellipsoid.semi_minor_metre,
                 inverse_flattening=self.ellipsoid.inverse_flattening,
             )
-            if self.ellipsoid.name not in unknown_names:
-                cf_dict["reference_ellipsoid_name"] = self.ellipsoid.name
+            cf_dict["reference_ellipsoid_name"] = self.ellipsoid.name
         if self.prime_meridian:
             cf_dict["longitude_of_prime_meridian"] = self.prime_meridian.longitude
-            if self.prime_meridian.name not in unknown_names:
-                cf_dict["prime_meridian_name"] = self.prime_meridian.name
+            cf_dict["prime_meridian_name"] = self.prime_meridian.name
 
         # handle geographic CRS
         if self.geodetic_crs:
@@ -637,20 +634,19 @@ class CRS(_CRS):
                         self.coordinate_operation.method_name.lower()
                     ](self.coordinate_operation)
                 )
-                if self.datum and self.datum.name not in unknown_names:
+                if self.datum:
                     cf_dict["horizontal_datum_name"] = self.datum.name
             else:
                 cf_dict["grid_mapping_name"] = "latitude_longitude"
             return cf_dict
 
         # handle projected CRS
-        if self.is_projected and self.datum and self.datum.name not in unknown_names:
+        if self.is_projected and self.datum:
             cf_dict["horizontal_datum_name"] = self.datum.name
         coordinate_operation = None
         if not self.is_bound and self.is_projected:
             coordinate_operation = self.coordinate_operation
-            if self.name not in unknown_names:
-                cf_dict["projected_crs_name"] = self.name
+            cf_dict["projected_crs_name"] = self.name
         coordinate_operation_name = (
             None
             if not coordinate_operation

--- a/test/crs/test_crs_cf.py
+++ b/test/crs/test_crs_cf.py
@@ -74,6 +74,7 @@ def test_to_cf_transverse_mercator():
         "false_northing": 0.0,
         "scale_factor_at_central_meridian": 0.9996,
         "geographic_crs_name": "unknown",
+        "projected_crs_name": "unknown",
     }
     cf_dict = crs.to_cf()
     assert cf_dict.pop("crs_wkt").startswith("BOUNDCRS[")
@@ -131,6 +132,8 @@ def test_from_cf_transverse_mercator(towgs84_test):
         "false_northing": 0.0,
         "scale_factor_at_central_meridian": 1.0,
         "geographic_crs_name": "undefined",
+        "projected_crs_name": "undefined",
+        "horizontal_datum_name": "undefined",
     }
     cf_dict = crs.to_cf()
     assert cf_dict.pop("crs_wkt").startswith("BOUNDCRS[")
@@ -157,6 +160,7 @@ def test_cf_from_latlon():
         "prime_meridian_name": "Greenwich",
         "grid_mapping_name": "latitude_longitude",
         "geographic_crs_name": "undefined",
+        "reference_ellipsoid_name": "undefined",
     }
     cf_dict = crs.to_cf()
     assert cf_dict.pop("crs_wkt").startswith("GEOGCRS[")
@@ -329,6 +333,7 @@ def test_cf_lambert_conformal_conic_1sp():
         "false_northing": 0.0,
         "standard_parallel": 25.0,
         "geographic_crs_name": "undefined",
+        "projected_crs_name": "undefined",
     }
     cf_dict = crs.to_cf()
     assert cf_dict.pop("crs_wkt").startswith("PROJCRS[")
@@ -378,6 +383,7 @@ def test_cf_lambert_conformal_conic_2sp(standard_parallel):
         "false_easting": 0.0,
         "false_northing": 0.0,
         "geographic_crs_name": "undefined",
+        "projected_crs_name": "undefined",
     }
     cf_dict = crs.to_cf()
     assert cf_dict.pop("crs_wkt").startswith("PROJCRS[")
@@ -429,6 +435,8 @@ def test_oblique_mercator():
         "false_easting": 0.0,
         "false_northing": 0.0,
         "geographic_crs_name": "undefined",
+        "projected_crs_name": "undefined",
+        "horizontal_datum_name": "undefined",
     }
     cf_dict = crs.to_cf()
     assert cf_dict.pop("crs_wkt").startswith("PROJCRS[")
@@ -502,6 +510,7 @@ def test_geos_crs_sweep():
         "false_easting": 0.0,
         "false_northing": 0.0,
         "geographic_crs_name": "undefined",
+        "projected_crs_name": "undefined",
     }
     cf_dict = crs.to_cf()
     assert cf_dict.pop("crs_wkt").startswith("PROJCRS[")
@@ -534,6 +543,7 @@ def test_geos_crs_fixed_angle_axis():
         "false_easting": 0.0,
         "false_northing": 0.0,
         "geographic_crs_name": "undefined",
+        "projected_crs_name": "undefined",
     }
     cf_dict = crs.to_cf()
     assert cf_dict.pop("crs_wkt").startswith("PROJCRS[")
@@ -558,6 +568,9 @@ def test_geos_proj_string():
         "false_easting": 0.0,
         "false_northing": 0.0,
         "geographic_crs_name": "unknown",
+        "horizontal_datum_name": "unknown",
+        "projected_crs_name": "unknown",
+        "reference_ellipsoid_name": "unknown",
     }
     cf_dict = crs.to_cf()
     assert cf_dict.pop("crs_wkt").startswith("PROJCRS[")
@@ -598,6 +611,7 @@ def test_mercator_b():
         "false_easting": 0.0,
         "false_northing": 0.0,
         "geographic_crs_name": "undefined",
+        "projected_crs_name": "undefined",
     }
     with pytest.warns(UserWarning):
         assert crs.to_dict() == {
@@ -823,6 +837,7 @@ def test_lambert_azimuthal_equal_area():
         "false_easting": 3.0,
         "false_northing": 4.0,
         "geographic_crs_name": "undefined",
+        "projected_crs_name": "undefined",
     }
     cf_dict = crs.to_cf()
     assert cf_dict.pop("crs_wkt").startswith("PROJCRS[")
@@ -847,6 +862,7 @@ def test_lambert_cylindrical_equal_area():
         "false_easting": 3.0,
         "false_northing": 4.0,
         "geographic_crs_name": "undefined",
+        "projected_crs_name": "undefined",
     }
     cf_dict = crs.to_cf()
     assert cf_dict.pop("crs_wkt").startswith("PROJCRS[")
@@ -872,6 +888,7 @@ def test_mercator_a():
         "false_northing": 4.0,
         "scale_factor_at_projection_origin": 1.0,
         "geographic_crs_name": "undefined",
+        "projected_crs_name": "undefined",
     }
     cf_dict = crs.to_cf()
     assert cf_dict.pop("crs_wkt").startswith("PROJCRS[")
@@ -896,6 +913,7 @@ def test_orthographic():
         "false_easting": 3.0,
         "false_northing": 4.0,
         "geographic_crs_name": "undefined",
+        "projected_crs_name": "undefined",
     }
     cf_dict = crs.to_cf()
     assert cf_dict.pop("crs_wkt").startswith("PROJCRS[")
@@ -921,6 +939,7 @@ def test_polar_stereographic_a():
         "false_northing": 3.0,
         "scale_factor_at_projection_origin": 1.0,
         "geographic_crs_name": "undefined",
+        "projected_crs_name": "undefined",
     }
     cf_dict = crs.to_cf()
     assert cf_dict.pop("crs_wkt").startswith("PROJCRS[")
@@ -945,6 +964,7 @@ def test_polar_stereographic_b():
         "false_easting": 2.0,
         "false_northing": 3.0,
         "geographic_crs_name": "undefined",
+        "projected_crs_name": "undefined",
     }
     cf_dict = crs.to_cf()
     assert cf_dict.pop("crs_wkt").startswith("PROJCRS[")
@@ -970,6 +990,7 @@ def test_stereographic():
         "false_northing": 3.0,
         "scale_factor_at_projection_origin": 1.0,
         "geographic_crs_name": "undefined",
+        "projected_crs_name": "undefined",
     }
     cf_dict = crs.to_cf()
     assert cf_dict.pop("crs_wkt").startswith("PROJCRS[")
@@ -993,6 +1014,7 @@ def test_sinusoidal():
         "false_easting": 1.0,
         "false_northing": 2.0,
         "geographic_crs_name": "undefined",
+        "projected_crs_name": "undefined",
     }
     cf_dict = crs.to_cf()
     assert cf_dict.pop("crs_wkt").startswith("PROJCRS[")
@@ -1018,6 +1040,7 @@ def test_vertical_perspective():
         "false_easting": 2.0,
         "false_northing": 3.0,
         "geographic_crs_name": "undefined",
+        "projected_crs_name": "undefined",
     }
     cf_dict = crs.to_cf()
     assert cf_dict.pop("crs_wkt").startswith("PROJCRS[")

--- a/test/crs/test_crs_cf.py
+++ b/test/crs/test_crs_cf.py
@@ -73,6 +73,7 @@ def test_to_cf_transverse_mercator():
         "false_easting": 2520000.0,
         "false_northing": 0.0,
         "scale_factor_at_central_meridian": 0.9996,
+        "geographic_crs_name": "unknown",
     }
     cf_dict = crs.to_cf()
     assert cf_dict.pop("crs_wkt").startswith("BOUNDCRS[")
@@ -129,6 +130,7 @@ def test_from_cf_transverse_mercator(towgs84_test):
         "false_easting": 2520000.0,
         "false_northing": 0.0,
         "scale_factor_at_central_meridian": 1.0,
+        "geographic_crs_name": "undefined",
     }
     cf_dict = crs.to_cf()
     assert cf_dict.pop("crs_wkt").startswith("BOUNDCRS[")
@@ -154,6 +156,7 @@ def test_cf_from_latlon():
         "longitude_of_prime_meridian": 0.0,
         "prime_meridian_name": "Greenwich",
         "grid_mapping_name": "latitude_longitude",
+        "geographic_crs_name": "undefined",
     }
     cf_dict = crs.to_cf()
     assert cf_dict.pop("crs_wkt").startswith("GEOGCRS[")
@@ -253,6 +256,7 @@ def test_cf_rotated_latlon():
         "grid_north_pole_latitude": 32.5,
         "grid_north_pole_longitude": 170.0,
         "north_pole_grid_longitude": 0.0,
+        "geographic_crs_name": "undefined",
     }
     cf_dict = crs.to_cf()
     assert cf_dict.pop("crs_wkt").startswith("GEOGCRS[")
@@ -324,6 +328,7 @@ def test_cf_lambert_conformal_conic_1sp():
         "false_easting": 0.0,
         "false_northing": 0.0,
         "standard_parallel": 25.0,
+        "geographic_crs_name": "undefined",
     }
     cf_dict = crs.to_cf()
     assert cf_dict.pop("crs_wkt").startswith("PROJCRS[")
@@ -372,6 +377,7 @@ def test_cf_lambert_conformal_conic_2sp(standard_parallel):
         "longitude_of_central_meridian": 265.0,
         "false_easting": 0.0,
         "false_northing": 0.0,
+        "geographic_crs_name": "undefined",
     }
     cf_dict = crs.to_cf()
     assert cf_dict.pop("crs_wkt").startswith("PROJCRS[")
@@ -422,6 +428,7 @@ def test_oblique_mercator():
         "scale_factor_at_projection_origin": 1.0,
         "false_easting": 0.0,
         "false_northing": 0.0,
+        "geographic_crs_name": "undefined",
     }
     cf_dict = crs.to_cf()
     assert cf_dict.pop("crs_wkt").startswith("PROJCRS[")
@@ -494,6 +501,7 @@ def test_geos_crs_sweep():
         "longitude_of_projection_origin": 0.0,
         "false_easting": 0.0,
         "false_northing": 0.0,
+        "geographic_crs_name": "undefined",
     }
     cf_dict = crs.to_cf()
     assert cf_dict.pop("crs_wkt").startswith("PROJCRS[")
@@ -525,6 +533,7 @@ def test_geos_crs_fixed_angle_axis():
         "longitude_of_projection_origin": 0.0,
         "false_easting": 0.0,
         "false_northing": 0.0,
+        "geographic_crs_name": "undefined",
     }
     cf_dict = crs.to_cf()
     assert cf_dict.pop("crs_wkt").startswith("PROJCRS[")
@@ -548,6 +557,7 @@ def test_geos_proj_string():
         "longitude_of_projection_origin": 0.0,
         "false_easting": 0.0,
         "false_northing": 0.0,
+        "geographic_crs_name": "unknown",
     }
     cf_dict = crs.to_cf()
     assert cf_dict.pop("crs_wkt").startswith("PROJCRS[")
@@ -587,6 +597,7 @@ def test_mercator_b():
         "longitude_of_projection_origin": 10.0,
         "false_easting": 0.0,
         "false_northing": 0.0,
+        "geographic_crs_name": "undefined",
     }
     with pytest.warns(UserWarning):
         assert crs.to_dict() == {
@@ -811,6 +822,7 @@ def test_lambert_azimuthal_equal_area():
         "longitude_of_projection_origin": 2.0,
         "false_easting": 3.0,
         "false_northing": 4.0,
+        "geographic_crs_name": "undefined",
     }
     cf_dict = crs.to_cf()
     assert cf_dict.pop("crs_wkt").startswith("PROJCRS[")
@@ -834,6 +846,7 @@ def test_lambert_cylindrical_equal_area():
         "longitude_of_central_meridian": 2.0,
         "false_easting": 3.0,
         "false_northing": 4.0,
+        "geographic_crs_name": "undefined",
     }
     cf_dict = crs.to_cf()
     assert cf_dict.pop("crs_wkt").startswith("PROJCRS[")
@@ -858,6 +871,7 @@ def test_mercator_a():
         "false_easting": 3.0,
         "false_northing": 4.0,
         "scale_factor_at_projection_origin": 1.0,
+        "geographic_crs_name": "undefined",
     }
     cf_dict = crs.to_cf()
     assert cf_dict.pop("crs_wkt").startswith("PROJCRS[")
@@ -881,6 +895,7 @@ def test_orthographic():
         "longitude_of_projection_origin": 2.0,
         "false_easting": 3.0,
         "false_northing": 4.0,
+        "geographic_crs_name": "undefined",
     }
     cf_dict = crs.to_cf()
     assert cf_dict.pop("crs_wkt").startswith("PROJCRS[")
@@ -905,6 +920,7 @@ def test_polar_stereographic_a():
         "false_easting": 2.0,
         "false_northing": 3.0,
         "scale_factor_at_projection_origin": 1.0,
+        "geographic_crs_name": "undefined",
     }
     cf_dict = crs.to_cf()
     assert cf_dict.pop("crs_wkt").startswith("PROJCRS[")
@@ -928,6 +944,7 @@ def test_polar_stereographic_b():
         "straight_vertical_longitude_from_pole": 1.0,
         "false_easting": 2.0,
         "false_northing": 3.0,
+        "geographic_crs_name": "undefined",
     }
     cf_dict = crs.to_cf()
     assert cf_dict.pop("crs_wkt").startswith("PROJCRS[")
@@ -952,6 +969,7 @@ def test_stereographic():
         "false_easting": 2.0,
         "false_northing": 3.0,
         "scale_factor_at_projection_origin": 1.0,
+        "geographic_crs_name": "undefined",
     }
     cf_dict = crs.to_cf()
     assert cf_dict.pop("crs_wkt").startswith("PROJCRS[")
@@ -974,6 +992,7 @@ def test_sinusoidal():
         "longitude_of_projection_origin": 0.0,
         "false_easting": 1.0,
         "false_northing": 2.0,
+        "geographic_crs_name": "undefined",
     }
     cf_dict = crs.to_cf()
     assert cf_dict.pop("crs_wkt").startswith("PROJCRS[")
@@ -998,6 +1017,7 @@ def test_vertical_perspective():
         "longitude_of_projection_origin": 1.0,
         "false_easting": 2.0,
         "false_northing": 3.0,
+        "geographic_crs_name": "undefined",
     }
     cf_dict = crs.to_cf()
     assert cf_dict.pop("crs_wkt").startswith("PROJCRS[")


### PR DESCRIPTION
This add the geographic_crs_name

 - [x] Closes #585 
 - [x] Tests added
 - [x] Fully documented, including `history.rst` for all changes and `api/*.rst` for new API
