### PR TITLE
Added pyproj.__proj_version__

### DIFF
--- a/docs/history.rst
+++ b/docs/history.rst
@@ -7,6 +7,7 @@ Change Log
 * BUG: Fix building prime meridian in :meth:`pyproj.crs.CRS.from_cf` (pull #588)
 * BUG: Fix check for numpy bool True kwarg (pull #590)
 * DOC: Update pyproj.Proj docstrings for clarity (issue #584)
+* Added `pyproj.__proj_version__`
 
 2.6.0
 ~~~~~

--- a/pyproj/__init__.py
+++ b/pyproj/__init__.py
@@ -45,7 +45,6 @@ __all__ = [
     "get_units_map",
     "show_versions",
 ]
-
 import warnings
 
 from pyproj import _datadir
@@ -64,6 +63,9 @@ from pyproj.exceptions import DataDirError, ProjError  # noqa: F401
 from pyproj.geod import Geod, geodesic_version_str, pj_ellps  # noqa: F401
 from pyproj.proj import Proj, pj_list, proj_version_str  # noqa: F401
 from pyproj.transformer import Transformer, itransform, transform  # noqa: F401
+
+__proj_version__ = proj_version_str
+
 
 try:
     _datadir.pyproj_global_context_initialize()

--- a/pyproj/__main__.py
+++ b/pyproj/__main__.py
@@ -7,7 +7,7 @@ e.g. python -m pyproj
 
 import argparse
 
-from pyproj import __version__, _show_versions, proj_version_str
+from pyproj import __proj_version__, __version__, _show_versions
 
 parser = argparse.ArgumentParser()
 parser.add_argument(
@@ -20,5 +20,5 @@ args = parser.parse_args()
 if args.verbose:
     _show_versions.show_versions()
 else:
-    print("pyproj version: {} [PROJ version: {}]".format(__version__, proj_version_str))
+    print("pyproj version: {} [PROJ version: {}]".format(__version__, __proj_version__))
     parser.print_help()

--- a/pyproj/_show_versions.py
+++ b/pyproj/_show_versions.py
@@ -43,7 +43,7 @@ def _get_proj_info():
 
     blob = [
         ("pyproj", pyproj.__version__),
-        ("PROJ", pyproj.proj_version_str),
+        ("PROJ", pyproj.__proj_version__),
         ("data dir", data_dir),
     ]
 

--- a/test/crs/test_crs.py
+++ b/test/crs/test_crs.py
@@ -4,7 +4,7 @@ from distutils.version import LooseVersion
 import numpy
 import pytest
 
-from pyproj import CRS, proj_version_str
+from pyproj import CRS, __proj_version__
 from pyproj.crs import (
     CoordinateOperation,
     CoordinateSystem,
@@ -560,7 +560,7 @@ def test_coordinate_operation_grids__alternative_grid_name():
     assert grid.direct_download is True
     assert grid.open_license is True
     assert grid.available is True
-    if LooseVersion(proj_version_str) >= LooseVersion("7.0.0"):
+    if LooseVersion(__proj_version__) >= LooseVersion("7.0.0"):
         assert grid.short_name == "ca_nrc_ntv1_can.tif"
         assert grid.full_name.endswith("ntv1_can.dat") or grid.full_name.endswith(
             grid.short_name
@@ -1197,7 +1197,7 @@ def test_to_dict_no_proj4():
             "proj": "ob_tran",
         }
     )
-    if LooseVersion(proj_version_str) >= LooseVersion("6.3.0"):
+    if LooseVersion(__proj_version__) >= LooseVersion("6.3.0"):
         with pytest.warns(UserWarning):
             assert crs.to_dict() == {
                 "R": 6371229,

--- a/test/crs/test_crs_cf.py
+++ b/test/crs/test_crs_cf.py
@@ -3,7 +3,7 @@ from distutils.version import LooseVersion
 import pytest
 from numpy.testing import assert_almost_equal
 
-from pyproj import CRS, proj_version_str
+from pyproj import CRS, __proj_version__
 from pyproj.crs import ProjectedCRS
 from pyproj.crs._cf1x8 import _try_list_if_string
 from pyproj.crs.coordinate_operation import (
@@ -269,7 +269,7 @@ def test_cf_rotated_latlon():
     _test_roundtrip(expected_cf, "GEOGCRS[")
     with pytest.warns(UserWarning):
         proj_dict = crs.to_dict()
-    if LooseVersion(proj_version_str) >= LooseVersion("6.3.0"):
+    if LooseVersion(__proj_version__) >= LooseVersion("6.3.0"):
         assert proj_dict == {
             "proj": "ob_tran",
             "o_proj": "longlat",
@@ -295,7 +295,7 @@ def test_cf_rotated_latlon__grid():
     )
     with pytest.warns(UserWarning):
         proj_dict = crs.to_dict()
-    if LooseVersion(proj_version_str) >= LooseVersion("6.3.0"):
+    if LooseVersion(__proj_version__) >= LooseVersion("6.3.0"):
         assert proj_dict == {
             "proj": "ob_tran",
             "o_proj": "longlat",
@@ -689,7 +689,7 @@ def test_export_compound_crs():
 
 
 @pytest.mark.skipif(
-    LooseVersion(proj_version_str) < LooseVersion("6.3.0"),
+    LooseVersion(__proj_version__) < LooseVersion("6.3.0"),
     reason="geoid model does not work in PROJ < 6.3.0",
 )
 def test_geoid_model_name():

--- a/test/crs/test_crs_coordinate_operation.py
+++ b/test/crs/test_crs_coordinate_operation.py
@@ -3,7 +3,7 @@ from distutils.version import LooseVersion
 import pytest
 from numpy.testing import assert_almost_equal
 
-from pyproj import proj_version_str
+from pyproj import __proj_version__
 from pyproj.crs import GeographicCRS
 from pyproj.crs.coordinate_operation import (
     AlbersEqualAreaConversion,
@@ -617,7 +617,7 @@ def test_rotated_latitude_longitude_operation():
 
 def test_lambert_cylindrical_equal_area_scale_operation__defaults():
     lceaop = LambertCylindricalEqualAreaScaleConversion()
-    if LooseVersion(proj_version_str) >= LooseVersion("6.3.1"):
+    if LooseVersion(__proj_version__) >= LooseVersion("6.3.1"):
         assert lceaop.name == "unknown"
         assert lceaop.method_name == "Lambert Cylindrical Equal Area"
         assert _to_dict(lceaop) == {
@@ -642,7 +642,7 @@ def test_lambert_cylindrical_equal_area_scale_operation():
         false_northing=4,
         scale_factor_natural_origin=0.999,
     )
-    if LooseVersion(proj_version_str) >= LooseVersion("6.3.1"):
+    if LooseVersion(__proj_version__) >= LooseVersion("6.3.1"):
         assert lceaop.name == "unknown"
         assert lceaop.method_name == "Lambert Cylindrical Equal Area"
         op_dict = _to_dict(lceaop)

--- a/test/crs/test_crs_maker.py
+++ b/test/crs/test_crs_maker.py
@@ -2,7 +2,7 @@ from distutils.version import LooseVersion
 
 import pytest
 
-from pyproj import proj_version_str
+from pyproj import __proj_version__
 from pyproj.crs import (
     BoundCRS,
     CompoundCRS,
@@ -62,7 +62,7 @@ def test_vertical_crs():
     assert vc.name == "NAVD88 height"
     assert vc.type_name == "Vertical CRS"
     assert vc.coordinate_system == VerticalCS()
-    if LooseVersion(proj_version_str) >= LooseVersion("6.3.0"):
+    if LooseVersion(__proj_version__) >= LooseVersion("6.3.0"):
         assert vc.to_json_dict()["geoid_model"]["name"] == "GEOID12B"
 
 

--- a/test/test_awips221.py
+++ b/test/test_awips221.py
@@ -3,7 +3,7 @@ import array
 import numpy
 from numpy.testing import assert_allclose
 
-from pyproj import Proj, proj_version_str
+from pyproj import Proj, __proj_version__
 
 try:
     from time import perf_counter
@@ -26,7 +26,7 @@ def test_awips221():
     # awips221 = Proj(params)
     # or keyword args
     awips221 = Proj(proj="lcc", R=6371200, lat_1=50, lat_2=50, lon_0=-107)
-    print("proj4 library version = ", proj_version_str)
+    print("proj4 library version = ", __proj_version__)
     # AWIPS grid 221 parameters
     # (from http://www.nco.ncep.noaa.gov/pmb/docs/on388/tableb.html)
     llcrnrx, llcrnry = awips221(-145.5, 1.0)

--- a/test/test_datum.py
+++ b/test/test_datum.py
@@ -3,7 +3,7 @@ from distutils.version import LooseVersion
 import pytest
 from numpy.testing import assert_almost_equal
 
-from pyproj import CRS, Proj, proj_version_str, transform
+from pyproj import CRS, Proj, __proj_version__, transform
 from test.conftest import grids_available
 
 
@@ -14,7 +14,7 @@ def test_datum(proj_class):
     s_2 = 45.25919444444
     p2 = proj_class(proj="utm", zone=10, datum="NAD27")
     x2, y2 = transform(p1, p2, s_1, s_2)
-    if LooseVersion(proj_version_str) < LooseVersion("6.3.0"):
+    if LooseVersion(__proj_version__) < LooseVersion("6.3.0"):
         assert_almost_equal(
             (x2, y2), (1402291.0833290431, 5076289.591846835), decimal=2
         )

--- a/test/test_datum_shift.py
+++ b/test/test_datum_shift.py
@@ -1,7 +1,7 @@
 import pytest
 from numpy.testing import assert_almost_equal
 
-from pyproj import Proj, proj_version_str, transform
+from pyproj import Proj, transform
 
 # illustrates the use of the transform function to
 # perform coordinate transformations with datum shifts.
@@ -33,7 +33,6 @@ with pytest.warns(FutureWarning):
     GAUSSSB_PROJ = Proj(
         init="epsg:3004", towgs84="-122.74,-34.27,-22.83,-1.884,-3.400,-3.030,-15.62"
     )
-print("proj4 library version = ", proj_version_str)
 
 
 def test_shift_wgs84_to_utm33():

--- a/test/test_transform.py
+++ b/test/test_transform.py
@@ -1,7 +1,7 @@
 import numpy
 from numpy.testing import assert_allclose
 
-from pyproj import Proj, proj_version_str, transform
+from pyproj import Proj, __proj_version__, transform
 
 
 def test_transform():
@@ -12,7 +12,7 @@ def test_transform():
     dx = 12190.58
     dy = dx
     awips221 = Proj(proj="lcc", R=6371200, lat_1=50, lat_2=50, lon_0=-107)
-    print("proj4 library version = ", proj_version_str)
+    print("proj4 library version = ", __proj_version__)
     llcrnrx, llcrnry = awips221(-145.5, 1)
     awips221 = Proj(
         proj="lcc",

--- a/test/test_transformer.py
+++ b/test/test_transformer.py
@@ -262,7 +262,7 @@ def test_transform_no_exception():
 def test_transform__out_of_bounds():
     with pytest.warns(FutureWarning):
         transformer = Transformer.from_proj("+init=epsg:4326", "+init=epsg:27700")
-    if LooseVersion(pyproj.proj_version_str) >= LooseVersion("7.0.0"):
+    if LooseVersion(pyproj.__proj_version__) >= LooseVersion("7.0.0"):
         with pytest.raises(pyproj.exceptions.ProjError):
             transformer.transform(100000, 100000, errcheck=True)
     else:
@@ -606,7 +606,7 @@ def test_transform_group__area_of_interest():
 
 def test_transformer_group__get_transform_crs():
     tg = TransformerGroup("epsg:4258", "epsg:7415")
-    if LooseVersion(pyproj.proj_version_str) >= LooseVersion("6.3.1"):
+    if LooseVersion(pyproj.__proj_version__) >= LooseVersion("6.3.1"):
         if not grids_available("nl_nsgi_rdtrans2018.tif"):
             assert len(tg.transformers) == 1
         else:


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Tests updated
 - [x] Fully documented, including `history.rst` for all changes and `api/*.rst` for new API


I like `__proj_version__` as it stands out as something more of a version identifier.
It also is consistent with `rasterio.__gdal_version` and `fiona.__gdal_version__`.

I am not sure that it is a big enough change to warrant a minor version bump.