### PR TITLE
BUG: fix unequal (!=) with non-CRS type

### DIFF
--- a/pyproj/crs/crs.py
+++ b/pyproj/crs/crs.py
@@ -905,6 +905,9 @@ class CRS(_CRS):
     def __eq__(self, other: Any) -> bool:
         return self.equals(other)
 
+    def __ne__(self, other: Any) -> bool:
+        return not self == other
+
     def __reduce__(self) -> Tuple[Type["CRS"], Tuple[str]]:
         """special method that allows CRS instance to be pickled"""
         return self.__class__, (self.srs,)

--- a/test/crs/test_crs.py
+++ b/test/crs/test_crs.py
@@ -1114,6 +1114,13 @@ def test_srs__no_plus():
 
 def test_equals_different_type():
     assert CRS("epsg:4326") != ""
+    assert not CRS("epsg:4326") == ""
+
+    assert CRS("epsg:4326") != 27700
+    assert not CRS("epsg:4326") == 27700
+
+    assert not CRS("epsg:4326") != 4326
+    assert CRS("epsg:4326") == 4326
 
 
 def test_is_exact_same_different_type():


### PR DESCRIPTION
See https://github.com/geopandas/geopandas/pull/1339#discussion_r407188802

Currently, you get

```
In [34]: CRS("epsg:4326") != 4326  
Out[34]: True
```

which should be False

 - [ ] Closes #xxxx
 - [x] Tests added
 - [ ] Fully documented, including `history.rst` for all changes and `api/*.rst` for new API
