### PR TITLE
TST: Simplify logic if shapely is available, remove old comments

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,5 +7,5 @@ numpy
 pylint
 pytest>3.6
 pytest-cov
-shapely; sys_platform != 'win32'  # shapely wheels not on Windows
+shapely
 pre-commit

--- a/test/test_doctest_wrapper.py
+++ b/test/test_doctest_wrapper.py
@@ -2,9 +2,6 @@
 This is a wrapper for the doctests in pyproj
 """
 import doctest
-import os
-import platform
-import sys
 import warnings
 
 import pytest
@@ -36,17 +33,12 @@ def test_doctests():
         + failure_count_geod
         + failure_count_transform
     )
-    # Missing shapely wheels for Windows, non x86_64 platforms, and python 3.8
     expected_failure_count = 0
     try:
         import shapely  # noqa
     except ImportError:
-        if (
-            os.name == "nt"
-            or platform.uname()[4] != "x86_64"
-            or (sys.version_info.major, sys.version_info.minor) >= (3, 8)
-        ):
-            expected_failure_count = 6
+        # missing shapely
+        expected_failure_count = 6
 
     # if the below line fails, doctests have failed
     assert (

--- a/test/test_geod.py
+++ b/test/test_geod.py
@@ -1,9 +1,7 @@
 import math
 import os
 import pickle
-import platform
 import shutil
-import sys
 import tempfile
 from contextlib import contextmanager
 
@@ -28,15 +26,7 @@ except ImportError:
     SHAPELY_LOADED = False
 
 
-skip_shapely = pytest.mark.skipif(
-    not SHAPELY_LOADED
-    and (
-        os.name == "nt"
-        or platform.uname()[4] != "x86_64"
-        or (sys.version_info.major, sys.version_info.minor) >= (3, 8)
-    ),
-    reason="Missing shapely wheels for Windows, non x86_64 platforms, and python 3.8.",
-)
+skip_shapely = pytest.mark.skipif(not SHAPELY_LOADED, reason="Missing shapely")
 
 
 @contextmanager


### PR DESCRIPTION
Since the start of 2020, Shapely 1.7.0 has binary wheels for Windows and Python 3.8, so some of the comments and logic used for testing is outdated. Furthermore, the test logic should only skip certain test if shapely is not installed in the test environment.