### PR TITLE
ENH: Datum.from_name default to check all datum types

### DIFF
--- a/docs/history.rst
+++ b/docs/history.rst
@@ -11,6 +11,7 @@ Change Log
 * ENH: Add network methods to Transformer (issue #629)
 * ENH: Use 'proj_get_units_from_database' in :func:`pyproj.get_units_map` & cleanup :func:`pyproj.get_codes` (issue #619)
 * ENH: Add support for radians for Proj & Transformer.from_pipeline & use less gil (issue #612)
+* ENH: Datum.from_name default to check all datum types (issue #606)
 
 2.6.1
 ~~~~~

--- a/test/crs/test_crs.py
+++ b/test/crs/test_crs.py
@@ -882,6 +882,13 @@ def test_datum_from_name__auth_type(auth_name):
         datum_type=DatumType.VERTICAL_REFERENCE_FRAME,
     )
     assert dd.name == "WGS_1984_Geoid"
+    assert dd.type_name == "Vertical Reference Frame"
+
+
+def test_datum_from_name__any_type():
+    dd = Datum.from_name("WGS_1984_Geoid")
+    assert dd.name == "WGS_1984_Geoid"
+    assert dd.type_name == "Vertical Reference Frame"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Part of #606
 - [x] Tests added
 - [x] Fully documented, including `history.rst` for all changes and `api/*.rst` for new API


Removed old `Datum.from_name` code that was only their for older versions of PROJ - no longer needed with PROJ >= 7.1 pin.

See: https://github.com/OSGeo/PROJ/issues/1823 & #631