### PR TITLE
CLN: PJ_WKT2_2018->PJ_WKT2_2019; remove ContextManager; ctypedef

### DIFF
--- a/pyproj/_crs.pyx
+++ b/pyproj/_crs.pyx
@@ -93,10 +93,10 @@ cdef _to_wkt(
     supported_wkt_types = {
         WktVersion.WKT2_2015: PJ_WKT2_2015,
         WktVersion.WKT2_2015_SIMPLIFIED: PJ_WKT2_2015_SIMPLIFIED,
-        WktVersion.WKT2_2018: PJ_WKT2_2018,
-        WktVersion.WKT2_2018_SIMPLIFIED: PJ_WKT2_2018_SIMPLIFIED,
-        WktVersion.WKT2_2019: PJ_WKT2_2018,
-        WktVersion.WKT2_2019_SIMPLIFIED: PJ_WKT2_2018_SIMPLIFIED,
+        WktVersion.WKT2_2018: PJ_WKT2_2019,
+        WktVersion.WKT2_2018_SIMPLIFIED: PJ_WKT2_2019_SIMPLIFIED,
+        WktVersion.WKT2_2019: PJ_WKT2_2019,
+        WktVersion.WKT2_2019_SIMPLIFIED: PJ_WKT2_2019_SIMPLIFIED,
         WktVersion.WKT1_GDAL: PJ_WKT1_GDAL,
         WktVersion.WKT1_ESRI: PJ_WKT1_ESRI
     }

--- a/pyproj/_datadir.pxd
+++ b/pyproj/_datadir.pxd
@@ -4,6 +4,3 @@ cdef void pyproj_context_initialize(
     PJ_CONTEXT* context,
     bint free_context_on_error,
     network=*) except *
-
-cdef class ContextManager:
-    cdef PJ_CONTEXT *context

--- a/pyproj/base.pxi
+++ b/pyproj/base.pxi
@@ -9,12 +9,13 @@ cdef int _DOUBLESIZE = sizeof(double)
 
 
 cdef extern from "math.h":
-    cdef enum:
+    ctypedef enum:
         HUGE_VAL
 
 
 cdef extern from "Python.h":
-    cdef int PyBUF_WRITABLE
+    ctypedef enum:
+        PyBUF_WRITABLE
     int PyObject_GetBuffer(PyObject *exporter, Py_buffer *view, int flags)
     void PyBuffer_Release(Py_buffer *view)
 

--- a/pyproj/proj.pxi
+++ b/pyproj/proj.pxi
@@ -1,9 +1,8 @@
 # PROJ.4 API Defnition
 cdef extern from "proj.h":
-    cdef enum:
-        PROJ_VERSION_MAJOR
-        PROJ_VERSION_MINOR
-        PROJ_VERSION_PATCH
+    cdef int PROJ_VERSION_MAJOR
+    cdef int PROJ_VERSION_MINOR
+    cdef int PROJ_VERSION_PATCH
     void proj_context_set_search_paths(
         PJ_CONTEXT *ctx, int count_paths, const char* const* paths)
     int proj_context_set_database_path(PJ_CONTEXT *ctx,
@@ -34,7 +33,7 @@ cdef extern from "proj.h":
     PJ *proj_create (PJ_CONTEXT *ctx, const char *definition)
     PJ *proj_normalize_for_visualization(PJ_CONTEXT *ctx, const PJ* obj)
 
-    cdef struct PJ_PROJ_INFO:
+    ctypedef struct PJ_PROJ_INFO:
         const char  *id
         const char  *description
         const char  *definition
@@ -71,7 +70,7 @@ cdef extern from "proj.h":
         double lam, phi,  z
 
 
-    cdef union PJ_COORD:
+    ctypedef union PJ_COORD:
         double v[4];
         PJ_XYZT xyzt;
         PJ_UVWT uvwt;
@@ -88,7 +87,7 @@ cdef extern from "proj.h":
 
     PJ_COORD proj_coord (double x, double y, double z, double t)
 
-    cdef enum PJ_DIRECTION:
+    ctypedef enum PJ_DIRECTION:
         PJ_FWD   =  1 # Forward
         PJ_IDENT =  0 # Do nothing
         PJ_INV   = -1 # Inverse
@@ -109,7 +108,7 @@ cdef extern from "proj.h":
     ctypedef struct PJ_AREA
     PJ *proj_create_crs_to_crs(PJ_CONTEXT *ctx, const char *source_crs, const char *target_crs, PJ_AREA *area)
 
-    cdef enum PJ_COMPARISON_CRITERION:
+    ctypedef enum PJ_COMPARISON_CRITERION:
         PJ_COMP_STRICT
         PJ_COMP_EQUIVALENT
         PJ_COMP_EQUIVALENT_EXCEPT_AXIS_ORDER_GEOGCRS
@@ -138,8 +137,8 @@ cdef extern from "proj.h":
     ctypedef enum PJ_WKT_TYPE:
         PJ_WKT2_2015
         PJ_WKT2_2015_SIMPLIFIED
-        PJ_WKT2_2018
-        PJ_WKT2_2018_SIMPLIFIED
+        PJ_WKT2_2019
+        PJ_WKT2_2019_SIMPLIFIED
         PJ_WKT1_GDAL
         PJ_WKT1_ESRI
 
@@ -357,10 +356,10 @@ cdef extern from "proj.h":
                                       int i_step)
 
     ctypedef enum PJ_CATEGORY:
-        PJ_CATEGORY_ELLIPSOID,
-        PJ_CATEGORY_PRIME_MERIDIAN,
-        PJ_CATEGORY_DATUM,
-        PJ_CATEGORY_CRS,
+        PJ_CATEGORY_ELLIPSOID
+        PJ_CATEGORY_PRIME_MERIDIAN
+        PJ_CATEGORY_DATUM
+        PJ_CATEGORY_CRS
         PJ_CATEGORY_COORDINATE_OPERATION
     PJ *proj_create_from_database(PJ_CONTEXT *ctx,
                                   const char *auth_name,


### PR DESCRIPTION
- PJ_WKT2_2018 is deprecated: https://github.com/OSGeo/PROJ/blob/af8334a5c8f6ec7d98e7f7ce0564ed4684896426/src/proj.h#L772-L773

- ContextManager is from pyproj 2.3 single context implementation and no longer needed

- Changed external declarations to use `ctypedef` instead of `cdef`