### PR TITLE
ENH: Use proj_is_equivalent_to_with_ctx in the place of proj_is_equivalent_to internally

### DIFF
--- a/docs/history.rst
+++ b/docs/history.rst
@@ -16,6 +16,7 @@ Change Log
 * ENH: Added :meth:`pyproj.transformer.TransformerGroup.download_grids` (pull #643)
 * ENH: Added transformation grid sync API/CLI (issue #572)
 * ENH: Add support for coordinate systems with CRS using CF conventions (issue #536)
+* ENH: Use `proj_is_equivalent_to_with_ctx` in the place of `proj_is_equivalent_to` internally (issue #666)
 
 2.6.1
 ~~~~~

--- a/pyproj/_crs.pyx
+++ b/pyproj/_crs.pyx
@@ -497,12 +497,12 @@ cdef class Base:
         return self.to_wkt(pretty=True)
 
     def _is_exact_same(self, Base other):
-        return proj_is_equivalent_to(
-            self.projobj, other.projobj, PJ_COMP_STRICT) == 1
+        return proj_is_equivalent_to_with_ctx(
+            self.context, self.projobj, other.projobj, PJ_COMP_STRICT) == 1
 
     def _is_equivalent(self, Base other):
-        return proj_is_equivalent_to(
-            self.projobj, other.projobj, PJ_COMP_EQUIVALENT) == 1
+        return proj_is_equivalent_to_with_ctx(
+            self.context, self.projobj, other.projobj, PJ_COMP_EQUIVALENT) == 1
 
     def __eq__(self, other):
         if not isinstance(other, Base):
@@ -2938,7 +2938,8 @@ cdef class _CRS(Base):
     def _equals(self, _CRS other, bint ignore_axis_order):
         if ignore_axis_order:
             # Only to be used with DerivedCRS/ProjectedCRS/GeographicCRS
-            return proj_is_equivalent_to(
+            return proj_is_equivalent_to_with_ctx(
+                self.context,
                 self.projobj,
                 other.projobj,
                 PJ_COMP_EQUIVALENT_EXCEPT_AXIS_ORDER_GEOGCRS,

--- a/pyproj/proj.pxi
+++ b/pyproj/proj.pxi
@@ -114,8 +114,9 @@ cdef extern from "proj.h":
         PJ_COMP_EQUIVALENT_EXCEPT_AXIS_ORDER_GEOGCRS
 
     void proj_destroy(PJ *obj)
-    int proj_is_equivalent_to(const PJ *obj, const PJ* other,
-                              PJ_COMPARISON_CRITERION criterion)
+    int proj_is_equivalent_to_with_ctx(PJ_CONTEXT *ctx,
+                                       const PJ *obj, const PJ *other,
+                                       PJ_COMPARISON_CRITERION criterion)
 
     const char* proj_get_id_auth_name(const PJ *obj, int index)
     const char* proj_get_id_code(const PJ *obj, int index)


### PR DESCRIPTION


<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Closes #666
 - [x] Fully documented, including `history.rst` for all changes and `api/*.rst` for new API
