### PR TITLE
BUG: CF to coordinate system fixes (unit-units;geodetic latitude;vertical direction)

### DIFF
--- a/docs/build_crs_cf.rst
+++ b/docs/build_crs_cf.rst
@@ -58,11 +58,13 @@ To get the coordinate system, you use :meth:`pyproj.crs.CRS.cs_to_cf`:
 Contents of `cf_coordinate_system`::
 
     [{'long_name': 'geodetic latitude coordinate',
-    'standard_name': 'geodetic latitude',
-    'unit': 'degrees_north'},
+    'standard_name': 'latitude',
+    'units': 'degrees_north',
+    'axis': 'Y'},
     {'long_name': 'geodetic longitude coordinate',
-    'standard_name': 'geodetic longitude',
-    'unit': 'degrees_east'}]
+    'standard_name': 'longitude',
+    'units': 'degrees_east',
+    'axis': 'X'}]
 
 
 Importing CRS from CF

--- a/pyproj/_crs.pyx
+++ b/pyproj/_crs.pyx
@@ -747,42 +747,45 @@ cdef class CoordinateSystem(_CRSParts):
                     axis=cf_axis,
                     long_name=axis["name"],
                     standard_name=f"projection_{cf_axis.lower()}_coordinate",
-                    unit=get_linear_unit(axis),
+                    units=get_linear_unit(axis),
                 ))
         elif self.name == "ellipsoidal":
             for axis in axis_list:
-                if axis["abbreviation"].upper() == "H":
+                if axis["abbreviation"].upper() in ("D", "H"):
                     cf_params.append(dict(
                         standard_name="height_above_reference_ellipsoid",
                         long_name=axis["name"],
-                        unit=axis["unit"],
+                        units=axis["unit"],
                         positive=axis["direction"],
                         axis="Z",
                     ))
                 else:
-                    name = axis["name"].lower()
+                    if "longitude" in axis["name"].lower():
+                        cf_axis = "X"
+                        name = "longitude"
+                    else:
+                        cf_axis = "Y"
+                        name = "latitude"
                     if rotated_pole:
                         cf_params.append(dict(
                             standard_name=f"grid_{name}",
                             long_name=f"{name} in rotated pole grid",
-                            unit="degrees",
+                            units="degrees",
+                            axis=cf_axis,
                         ))
                     else:
                         cf_params.append(dict(
                             standard_name=name,
                             long_name=f"{name} coordinate",
-                            unit=f'degrees_{axis["direction"]}',
+                            units=f'degrees_{axis["direction"]}',
+                            axis=cf_axis,
                         ))
         elif self.name == "vertical":
             for axis in axis_list:
-                if axis["abbreviation"].upper() == "H":
-                    standard_name = "height"
-                else:
-                    standard_name = "depth"
                 cf_params.append(dict(
-                    standard_name=standard_name,
+                    standard_name="height_above_reference_ellipsoid",
                     long_name=axis["name"],
-                    unit=get_linear_unit(axis),
+                    units=get_linear_unit(axis),
                     positive=axis["direction"],
                     axis="Z",
                 ))

--- a/test/crs/test_crs_cf.py
+++ b/test/crs/test_crs_cf.py
@@ -85,13 +85,13 @@ def test_to_cf_transverse_mercator():
             "axis": "X",
             "long_name": "Easting",
             "standard_name": "projection_x_coordinate",
-            "unit": "metre",
+            "units": "metre",
         },
         {
             "axis": "Y",
             "long_name": "Northing",
             "standard_name": "projection_y_coordinate",
-            "unit": "metre",
+            "units": "metre",
         },
     ]
 
@@ -128,7 +128,6 @@ def test_from_cf_transverse_mercator(towgs84_test):
             "false_northing": 0,
             "reference_ellipsoid_name": "intl",
             "towgs84": towgs84_test,
-            "unit": "m",
         }
     )
     expected_cf = {
@@ -161,13 +160,13 @@ def test_from_cf_transverse_mercator(towgs84_test):
             "axis": "X",
             "long_name": "Easting",
             "standard_name": "projection_x_coordinate",
-            "unit": "metre",
+            "units": "metre",
         },
         {
             "axis": "Y",
             "long_name": "Northing",
             "standard_name": "projection_y_coordinate",
-            "unit": "metre",
+            "units": "metre",
         },
     ]
 
@@ -200,12 +199,14 @@ def test_cf_from_latlon():
         {
             "standard_name": "longitude",
             "long_name": "longitude coordinate",
-            "unit": "degrees_east",
+            "units": "degrees_east",
+            "axis": "X",
         },
         {
             "standard_name": "latitude",
             "long_name": "latitude coordinate",
-            "unit": "degrees_north",
+            "units": "degrees_north",
+            "axis": "Y",
         },
     ]
 
@@ -259,13 +260,13 @@ def test_cf_from_utm():
             "axis": "X",
             "long_name": "Easting",
             "standard_name": "projection_x_coordinate",
-            "unit": "metre",
+            "units": "metre",
         },
         {
             "axis": "Y",
             "long_name": "Northing",
             "standard_name": "projection_y_coordinate",
-            "unit": "metre",
+            "units": "metre",
         },
     ]
 
@@ -300,13 +301,13 @@ def test_cf_from_utm__nad83():
             "axis": "X",
             "long_name": "Easting",
             "standard_name": "projection_x_coordinate",
-            "unit": "metre",
+            "units": "metre",
         },
         {
             "axis": "Y",
             "long_name": "Northing",
             "standard_name": "projection_y_coordinate",
-            "unit": "metre",
+            "units": "metre",
         },
     ]
 
@@ -343,12 +344,14 @@ def test_cf_rotated_latlon():
         {
             "standard_name": "grid_longitude",
             "long_name": "longitude in rotated pole grid",
-            "unit": "degrees",
+            "units": "degrees",
+            "axis": "X",
         },
         {
             "standard_name": "grid_latitude",
             "long_name": "latitude in rotated pole grid",
-            "unit": "degrees",
+            "units": "degrees",
+            "axis": "Y",
         },
     ]
     with pytest.warns(UserWarning):
@@ -424,13 +427,13 @@ def test_cf_lambert_conformal_conic_1sp():
             "axis": "X",
             "long_name": "Easting",
             "standard_name": "projection_x_coordinate",
-            "unit": "metre",
+            "units": "metre",
         },
         {
             "axis": "Y",
             "long_name": "Northing",
             "standard_name": "projection_y_coordinate",
-            "unit": "metre",
+            "units": "metre",
         },
     ]
 
@@ -489,13 +492,13 @@ def test_cf_lambert_conformal_conic_2sp(standard_parallel):
             "axis": "X",
             "long_name": "Easting",
             "standard_name": "projection_x_coordinate",
-            "unit": "metre",
+            "units": "metre",
         },
         {
             "axis": "Y",
             "long_name": "Northing",
             "standard_name": "projection_y_coordinate",
-            "unit": "metre",
+            "units": "metre",
         },
     ]
     with pytest.warns(UserWarning):
@@ -556,13 +559,13 @@ def test_oblique_mercator():
             "axis": "X",
             "long_name": "Easting",
             "standard_name": "projection_x_coordinate",
-            "unit": "metre",
+            "units": "metre",
         },
         {
             "axis": "Y",
             "long_name": "Northing",
             "standard_name": "projection_y_coordinate",
-            "unit": "metre",
+            "units": "metre",
         },
     ]
     with pytest.warns(UserWarning):
@@ -645,13 +648,13 @@ def test_geos_crs_sweep():
             "axis": "X",
             "long_name": "Easting",
             "standard_name": "projection_x_coordinate",
-            "unit": "metre",
+            "units": "metre",
         },
         {
             "axis": "Y",
             "long_name": "Northing",
             "standard_name": "projection_y_coordinate",
-            "unit": "metre",
+            "units": "metre",
         },
     ]
 
@@ -693,13 +696,13 @@ def test_geos_crs_fixed_angle_axis():
             "axis": "X",
             "long_name": "Easting",
             "standard_name": "projection_x_coordinate",
-            "unit": "metre",
+            "units": "metre",
         },
         {
             "axis": "Y",
             "long_name": "Northing",
             "standard_name": "projection_y_coordinate",
-            "unit": "metre",
+            "units": "metre",
         },
     ]
 
@@ -735,13 +738,13 @@ def test_geos_proj_string():
             "axis": "X",
             "long_name": "Easting",
             "standard_name": "projection_x_coordinate",
-            "unit": "metre",
+            "units": "metre",
         },
         {
             "axis": "Y",
             "long_name": "Northing",
             "standard_name": "projection_y_coordinate",
-            "unit": "metre",
+            "units": "metre",
         },
     ]
 
@@ -803,13 +806,13 @@ def test_mercator_b():
             "axis": "X",
             "long_name": "Easting",
             "standard_name": "projection_x_coordinate",
-            "unit": "metre",
+            "units": "metre",
         },
         {
             "axis": "Y",
             "long_name": "Northing",
             "standard_name": "projection_y_coordinate",
-            "unit": "metre",
+            "units": "metre",
         },
     ]
 
@@ -847,13 +850,13 @@ def test_osgb_1936():
             "axis": "X",
             "long_name": "Easting",
             "standard_name": "projection_x_coordinate",
-            "unit": "metre",
+            "units": "metre",
         },
         {
             "axis": "Y",
             "long_name": "Northing",
             "standard_name": "projection_y_coordinate",
-            "unit": "metre",
+            "units": "metre",
         },
     ]
 
@@ -889,18 +892,18 @@ def test_export_compound_crs():
             "axis": "Y",
             "long_name": "Northing",
             "standard_name": "projection_y_coordinate",
-            "unit": "metre",
+            "units": "metre",
         },
         {
             "axis": "X",
             "long_name": "Easting",
             "standard_name": "projection_x_coordinate",
-            "unit": "metre",
+            "units": "metre",
         },
         {
             "standard_name": "height",
             "long_name": "Gravity-related height",
-            "unit": "metre",
+            "units": "metre",
             "positive": "up",
             "axis": "Z",
         },
@@ -988,18 +991,18 @@ def test_geoid_model_name():
             "axis": "X",
             "long_name": "Easting",
             "standard_name": "projection_x_coordinate",
-            "unit": "metre",
+            "units": "metre",
         },
         {
             "axis": "Y",
             "long_name": "Northing",
             "standard_name": "projection_y_coordinate",
-            "unit": "metre",
+            "units": "metre",
         },
         {
             "standard_name": "height",
             "long_name": "Gravity-related height",
-            "unit": "metre",
+            "units": "metre",
             "positive": "up",
             "axis": "Z",
         },
@@ -1036,13 +1039,13 @@ def test_albers_conical_equal_area():
             "axis": "X",
             "long_name": "Easting",
             "standard_name": "projection_x_coordinate",
-            "unit": "metre",
+            "units": "metre",
         },
         {
             "axis": "Y",
             "long_name": "Northing",
             "standard_name": "projection_y_coordinate",
-            "unit": "metre",
+            "units": "metre",
         },
     ]
 
@@ -1076,13 +1079,13 @@ def test_azimuthal_equidistant():
             "axis": "X",
             "long_name": "Easting",
             "standard_name": "projection_x_coordinate",
-            "unit": "metre",
+            "units": "metre",
         },
         {
             "axis": "Y",
             "long_name": "Northing",
             "standard_name": "projection_y_coordinate",
-            "unit": "metre",
+            "units": "metre",
         },
     ]
 
@@ -1116,13 +1119,13 @@ def test_lambert_azimuthal_equal_area():
             "axis": "X",
             "long_name": "Easting",
             "standard_name": "projection_x_coordinate",
-            "unit": "metre",
+            "units": "metre",
         },
         {
             "axis": "Y",
             "long_name": "Northing",
             "standard_name": "projection_y_coordinate",
-            "unit": "metre",
+            "units": "metre",
         },
     ]
 
@@ -1156,13 +1159,13 @@ def test_lambert_cylindrical_equal_area():
             "axis": "X",
             "long_name": "Easting",
             "standard_name": "projection_x_coordinate",
-            "unit": "metre",
+            "units": "metre",
         },
         {
             "axis": "Y",
             "long_name": "Northing",
             "standard_name": "projection_y_coordinate",
-            "unit": "metre",
+            "units": "metre",
         },
     ]
 
@@ -1197,13 +1200,13 @@ def test_mercator_a():
             "axis": "X",
             "long_name": "Easting",
             "standard_name": "projection_x_coordinate",
-            "unit": "metre",
+            "units": "metre",
         },
         {
             "axis": "Y",
             "long_name": "Northing",
             "standard_name": "projection_y_coordinate",
-            "unit": "metre",
+            "units": "metre",
         },
     ]
 
@@ -1237,13 +1240,13 @@ def test_orthographic():
             "axis": "X",
             "long_name": "Easting",
             "standard_name": "projection_x_coordinate",
-            "unit": "metre",
+            "units": "metre",
         },
         {
             "axis": "Y",
             "long_name": "Northing",
             "standard_name": "projection_y_coordinate",
-            "unit": "metre",
+            "units": "metre",
         },
     ]
 
@@ -1278,13 +1281,13 @@ def test_polar_stereographic_a():
             "axis": "X",
             "long_name": "Easting",
             "standard_name": "projection_x_coordinate",
-            "unit": "metre",
+            "units": "metre",
         },
         {
             "axis": "Y",
             "long_name": "Northing",
             "standard_name": "projection_y_coordinate",
-            "unit": "metre",
+            "units": "metre",
         },
     ]
 
@@ -1318,13 +1321,13 @@ def test_polar_stereographic_b():
             "axis": "X",
             "long_name": "Easting",
             "standard_name": "projection_x_coordinate",
-            "unit": "metre",
+            "units": "metre",
         },
         {
             "axis": "Y",
             "long_name": "Northing",
             "standard_name": "projection_y_coordinate",
-            "unit": "metre",
+            "units": "metre",
         },
     ]
 
@@ -1359,13 +1362,13 @@ def test_stereographic():
             "axis": "X",
             "long_name": "Easting",
             "standard_name": "projection_x_coordinate",
-            "unit": "metre",
+            "units": "metre",
         },
         {
             "axis": "Y",
             "long_name": "Northing",
             "standard_name": "projection_y_coordinate",
-            "unit": "metre",
+            "units": "metre",
         },
     ]
 
@@ -1398,13 +1401,13 @@ def test_sinusoidal():
             "axis": "X",
             "long_name": "Easting",
             "standard_name": "projection_x_coordinate",
-            "unit": "metre",
+            "units": "metre",
         },
         {
             "axis": "Y",
             "long_name": "Northing",
             "standard_name": "projection_y_coordinate",
-            "unit": "metre",
+            "units": "metre",
         },
     ]
 
@@ -1439,13 +1442,13 @@ def test_vertical_perspective():
             "axis": "X",
             "long_name": "Easting",
             "standard_name": "projection_x_coordinate",
-            "unit": "metre",
+            "units": "metre",
         },
         {
             "axis": "Y",
             "long_name": "Northing",
             "standard_name": "projection_y_coordinate",
-            "unit": "metre",
+            "units": "metre",
         },
     ]
 
@@ -1547,13 +1550,13 @@ def test_cartesian_cs():
             "axis": "X",
             "long_name": "Easting",
             "standard_name": "projection_x_coordinate",
-            "unit": "0.3048 metre",
+            "units": "0.3048 metre",
         },
         {
             "axis": "Y",
             "long_name": "Northing",
             "standard_name": "projection_y_coordinate",
-            "unit": "0.3048 metre",
+            "units": "0.3048 metre",
         },
     ]
 
@@ -1592,12 +1595,14 @@ def test_ellipsoidal_cs():
         {
             "standard_name": "latitude",
             "long_name": "latitude coordinate",
-            "unit": "degrees_north",
+            "units": "degrees_north",
+            "axis": "Y",
         },
         {
             "standard_name": "longitude",
             "long_name": "longitude coordinate",
-            "unit": "degrees_east",
+            "units": "degrees_east",
+            "axis": "X",
         },
     ]
 
@@ -1632,12 +1637,14 @@ def test_ellipsoidal_cs__from_name():
         {
             "standard_name": "longitude",
             "long_name": "longitude coordinate",
-            "unit": "degrees_east",
+            "units": "degrees_east",
+            "axis": "X",
         },
         {
             "standard_name": "latitude",
             "long_name": "latitude coordinate",
-            "unit": "degrees_north",
+            "units": "degrees_north",
+            "axis": "Y",
         },
     ]
 
@@ -1702,19 +1709,115 @@ def test_export_compound_crs_cs():
             "axis": "Y",
             "long_name": "Northing",
             "standard_name": "projection_y_coordinate",
-            "unit": "0.3048 metre",
+            "units": "0.3048 metre",
         },
         {
             "axis": "X",
             "long_name": "Easting",
             "standard_name": "projection_x_coordinate",
-            "unit": "0.3048 metre",
+            "units": "0.3048 metre",
         },
         {
             "standard_name": "height",
             "long_name": "Gravity-related height",
-            "unit": "0.3048 metre",
+            "units": "0.3048 metre",
             "positive": "up",
+            "axis": "Z",
+        },
+    ]
+
+
+def test_ellipsoidal_cs__geodetic():
+    crs = CRS.from_epsg(4326)
+    crs.cs_to_cf() == [
+        {
+            "standard_name": "latitude",
+            "long_name": "geodetic latitude coordinate",
+            "units": "degrees_north",
+            "axis": "Y",
+        },
+        {
+            "standard_name": "longitude",
+            "long_name": "geodetic longitude coordinate",
+            "units": "degrees_east",
+            "axis": "X",
+        },
+    ]
+
+
+def test_3d_ellipsoidal_cs_depth():
+    crs = CRS(
+        {
+            "$schema": "https://proj.org/schemas/v0.2/projjson.schema.json",
+            "type": "GeographicCRS",
+            "name": "WGS 84 (geographic 3D)",
+            "datum": {
+                "type": "GeodeticReferenceFrame",
+                "name": "World Geodetic System 1984",
+                "ellipsoid": {
+                    "name": "WGS 84",
+                    "semi_major_axis": 6378137,
+                    "inverse_flattening": 298.257223563,
+                },
+            },
+            "coordinate_system": {
+                "subtype": "ellipsoidal",
+                "axis": [
+                    {
+                        "name": "Geodetic latitude",
+                        "abbreviation": "Lat",
+                        "direction": "north",
+                        "unit": {
+                            "type": "AngularUnit",
+                            "name": "degree minute second hemisphere",
+                            "conversion_factor": 0.0174532925199433,
+                        },
+                    },
+                    {
+                        "name": "Geodetic longitude",
+                        "abbreviation": "Long",
+                        "direction": "east",
+                        "unit": {
+                            "type": "AngularUnit",
+                            "name": "degree minute second hemisphere",
+                            "conversion_factor": 0.0174532925199433,
+                        },
+                    },
+                    {
+                        "name": "Ellipsoidal depth",
+                        "abbreviation": "d",
+                        "direction": "down",
+                        "unit": "metre",
+                    },
+                ],
+            },
+            "area": "World",
+            "bbox": {
+                "south_latitude": -90,
+                "west_longitude": -180,
+                "north_latitude": 90,
+                "east_longitude": 180,
+            },
+        }
+    )
+    crs.cs_to_cf() == [
+        {
+            "standard_name": "latitude",
+            "long_name": "geodetic latitude coordinate",
+            "units": "degrees_north",
+            "axis": "Y",
+        },
+        {
+            "standard_name": "longitude",
+            "long_name": "geodetic longitude coordinate",
+            "units": "degrees_east",
+            "axis": "X",
+        },
+        {
+            "standard_name": "height_above_reference_ellipsoid",
+            "long_name": "Ellipsoidal depth",
+            "units": "metre",
+            "positive": "down",
             "axis": "Z",
         },
     ]

--- a/test/crs/test_crs_cf.py
+++ b/test/crs/test_crs_cf.py
@@ -901,7 +901,7 @@ def test_export_compound_crs():
             "units": "metre",
         },
         {
-            "standard_name": "height",
+            "standard_name": "height_above_reference_ellipsoid",
             "long_name": "Gravity-related height",
             "units": "metre",
             "positive": "up",
@@ -1000,7 +1000,7 @@ def test_geoid_model_name():
             "units": "metre",
         },
         {
-            "standard_name": "height",
+            "standard_name": "height_above_reference_ellipsoid",
             "long_name": "Gravity-related height",
             "units": "metre",
             "positive": "up",
@@ -1718,7 +1718,7 @@ def test_export_compound_crs_cs():
             "units": "0.3048 metre",
         },
         {
-            "standard_name": "height",
+            "standard_name": "height_above_reference_ellipsoid",
             "long_name": "Gravity-related height",
             "units": "0.3048 metre",
             "positive": "up",

--- a/test/crs/test_crs_coordinate_system.py
+++ b/test/crs/test_crs_coordinate_system.py
@@ -171,12 +171,14 @@ def test_ellipsoidal2dcs_to_cf():
         {
             "standard_name": "latitude",
             "long_name": "latitude coordinate",
-            "unit": "degrees_north",
+            "units": "degrees_north",
+            "axis": "Y",
         },
         {
             "standard_name": "longitude",
             "long_name": "longitude coordinate",
-            "unit": "degrees_east",
+            "units": "degrees_east",
+            "axis": "X",
         },
     ]
 
@@ -187,17 +189,19 @@ def test_ellipsoidal3dcs_to_cf():
         {
             "standard_name": "longitude",
             "long_name": "longitude coordinate",
-            "unit": "degrees_east",
+            "units": "degrees_east",
+            "axis": "X",
         },
         {
             "standard_name": "latitude",
             "long_name": "latitude coordinate",
-            "unit": "degrees_north",
+            "units": "degrees_north",
+            "axis": "Y",
         },
         {
             "standard_name": "height_above_reference_ellipsoid",
             "long_name": "Ellipsoidal height",
-            "unit": "metre",
+            "units": "metre",
             "positive": "up",
             "axis": "Z",
         },
@@ -211,13 +215,13 @@ def test_cartesian2dcs_ft_to_cf():
             "axis": "Y",
             "long_name": "Northing",
             "standard_name": "projection_y_coordinate",
-            "unit": "0.3048 metre",
+            "units": "0.3048 metre",
         },
         {
             "axis": "X",
             "long_name": "Easting",
             "standard_name": "projection_x_coordinate",
-            "unit": "0.3048 metre",
+            "units": "0.3048 metre",
         },
     ]
 
@@ -229,13 +233,13 @@ def test_cartesian2dcs_to_cf():
             "axis": "Y",
             "long_name": "Northing",
             "standard_name": "projection_y_coordinate",
-            "unit": "metre",
+            "units": "metre",
         },
         {
             "axis": "X",
             "long_name": "Easting",
             "standard_name": "projection_x_coordinate",
-            "unit": "metre",
+            "units": "metre",
         },
     ]
 
@@ -244,9 +248,9 @@ def test_verticalcs_depth_to_cf():
     vcs = VerticalCS(axis=VerticalCSAxis.DEPTH)
     vcs.to_cf() == [
         {
-            "standard_name": "depth",
+            "standard_name": "height_above_reference_ellipsoid",
             "long_name": "Depth",
-            "unit": "metre",
+            "units": "metre",
             "positive": "down",
             "axis": "Z",
         }
@@ -257,9 +261,9 @@ def test_verticalcs_height_to_cf():
     vcs = VerticalCS(axis=VerticalCSAxis.GRAVITY_HEIGHT_US_FT)
     vcs.to_cf() == [
         {
-            "standard_name": "height",
+            "standard_name": "height_above_reference_ellipsoid",
             "long_name": "Gravity-related height",
-            "unit": "0.304800609601219 metre",
+            "units": "0.304800609601219 metre",
             "positive": "up",
             "axis": "Z",
         }


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Tests added


1. unit -> units
2. standard_name should be `latitude` & not geodetic latitude
3. The distinction of being depth or not will be managed by `direction` only. Changing `standard_name` as well is incorrect ([ref](http://cfconventions.org/cf-conventions/cf-conventions.html#vertical-coordinate))
4. Added `axis` for lon/lat "Optionally, the longitude type may be indicated additionally by providing the standard_name attribute with the value longitude, and/or the axis attribute with the value X."