### PR TITLE
BUG: Ensure geojson opened with encoding=utf-8

### DIFF
--- a/pyproj/sync.py
+++ b/pyproj/sync.py
@@ -266,7 +266,7 @@ def _load_grid_geojson(target_directory=None) -> Dict[str, Any]:
             short_name="files.geojson",
             directory=target_directory,
         )
-    with open(local_path) as gridf:
+    with open(local_path, encoding="utf-8") as gridf:
         return json.load(gridf)
 
 


### PR DESCRIPTION
Addresses this error from: https://travis-ci.com/github/pyproj4/pyproj-wheels/jobs/361979395
```
>       return codecs.ascii_decode(input, self.errors)[0]

E       UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 210: ordinal not in range(128)
```