### PR TITLE
BUG: Fix handling of polygon holes when calculating area in Geod

### DIFF
--- a/pyproj/geod.py
+++ b/pyproj/geod.py
@@ -550,13 +550,13 @@ class Geod(_Geod):
         >>> poly_area, poly_perimeter = geod.geometry_area_perimeter(
         ...     Polygon(
         ...         LineString([
-        ...             Point(1, 1), Point(1, 10), Point(10, 10), Point(10, 1)
+        ...             Point(1, 1), Point(10, 1), Point(10, 10), Point(1, 10)
         ...         ]),
         ...         holes=[LineString([Point(1, 2), Point(3, 4), Point(5, 2)])],
         ...     )
         ... )
         >>> f"{poly_area:.3f} {poly_perimeter:.3f}"
-        '-944373881400.339 3979008.036'
+        '944373881400.339 3979008.036'
 
 
         Parameters

--- a/pyproj/geod.py
+++ b/pyproj/geod.py
@@ -530,10 +530,11 @@ class Geod(_Geod):
 
         .. note:: lats should be in the range [-90 deg, 90 deg].
 
-        .. warning:: The area returned is signed with counter-clockwise (CCW) traversal being
-                     treated as positive. For polygons, holes should use the opposite traversal
-                     to the exterior (if the exterior is CCW, the holes/interiors should be CW)
-                     You can use `shapely.ops.orient` to modify the orientation.
+        .. warning:: The area returned is signed with counter-clockwise (CCW) traversal
+                     being treated as positive. For polygons, holes should use the
+                     opposite traversal to the exterior (if the exterior is CCW, the
+                     holes/interiors should be CW). You can use `shapely.ops.orient` to
+                     modify the orientation.
 
         If it is a Polygon, it will return the area and exterior perimeter.
         It will subtract the area of the interior holes.

--- a/pyproj/geod.py
+++ b/pyproj/geod.py
@@ -530,9 +530,10 @@ class Geod(_Geod):
 
         .. note:: lats should be in the range [-90 deg, 90 deg].
 
-        .. warning:: The area returned is signed with counter-clockwise traversal being
-                     treated as positive. You can use `shapely.ops.orient` to modify the
-                     orientation.
+        .. warning:: The area returned is signed with counter-clockwise (CCW) traversal being
+                     treated as positive. For polygons, holes should use the opposite traversal
+                     to the exterior (if the exterior is CCW, the holes/interiors should be CW)
+                     You can use `shapely.ops.orient` to modify the orientation.
 
         If it is a Polygon, it will return the area and exterior perimeter.
         It will subtract the area of the interior holes.
@@ -583,7 +584,7 @@ class Geod(_Geod):
             # subtract area of holes
             for hole in geometry.interiors:
                 area, _ = self.geometry_area_perimeter(hole, radians=radians)
-                total_area -= area
+                total_area += area
             return total_area, total_perimeter
         # multi geometries
         elif hasattr(geometry, "geoms"):

--- a/test/test_geod.py
+++ b/test/test_geod.py
@@ -381,7 +381,7 @@ def test_geometry_area_perimeter__polygon__radians():
 @skip_shapely
 def test_geometry_area_perimeter__polygon__holes():
     geod = Geod(ellps="WGS84")
-    
+
     polygon = Polygon(
         LineString([Point(1, 1), Point(1, 10), Point(10, 10), Point(10, 1)]),
         holes=[LineString([Point(1, 2), Point(3, 4), Point(5, 2)])],

--- a/test/test_geod.py
+++ b/test/test_geod.py
@@ -21,6 +21,7 @@ try:
         Point,
         Polygon,
     )
+    from shapely.geometry.polygon import orient
 
     SHAPELY_LOADED = True
 except ImportError:
@@ -380,17 +381,23 @@ def test_geometry_area_perimeter__polygon__radians():
 @skip_shapely
 def test_geometry_area_perimeter__polygon__holes():
     geod = Geod(ellps="WGS84")
+    
+    polygon = Polygon(
+        LineString([Point(1, 1), Point(1, 10), Point(10, 10), Point(10, 1)]),
+        holes=[LineString([Point(1, 2), Point(3, 4), Point(5, 2)])],
+    )
+
     assert_almost_equal(
-        geod.geometry_area_perimeter(
-            Polygon(
-                LineString([Point(1, 1), Point(1, 10), Point(10, 10), Point(10, 1)]),
-                holes=[LineString([Point(1, 2), Point(3, 4), Point(5, 2)])],
-            )
-        ),
-        (-944373881400.3394, 3979008.0359657984),
+        geod.geometry_area_perimeter(orient(polygon, 1)),
+        (944373881400.3394, 3979008.0359657984),
         decimal=2,
     )
 
+    assert_almost_equal(
+        geod.geometry_area_perimeter(orient(polygon, -1)),
+        (-944373881400.3394, 3979008.0359657984),
+        decimal=2,
+    )
 
 @skip_shapely
 def test_geometry_area_perimeter__multipolygon():

--- a/test/test_geod.py
+++ b/test/test_geod.py
@@ -399,6 +399,7 @@ def test_geometry_area_perimeter__polygon__holes():
         decimal=2,
     )
 
+
 @skip_shapely
 def test_geometry_area_perimeter__multipolygon():
     geod = Geod(ellps="WGS84")


### PR DESCRIPTION
Because `geod.geometry_area_perimeter` is signed, the handedness of the geometries coming in matters. There is an existing comment that says that counter-clockwise windings result in positive areas. The docs also point to the `shapely.geometry.polygon.orient` function which winds a polygon according to either the right-hand or left-hand rule. From the Shapely [docs](https://shapely.readthedocs.io/en/latest/manual.html#shapely.geometry.polygon.orient):
> A sign of 1.0 means that the coordinates of the product’s exterior ring will be oriented counter-clockwise and the interior rings (holes) will be oriented clockwise.

That means that if you are finding the area of a polygon wound using `orient`, the exterior would generate a positive area and the interiors (holes) would generate negative areas. As is, `Geod` **subtracts** the holes' areas which results in `area_exterior + area_interiors` instead of `area_exterior - area_interiors`. Simply changing to an addition resolves the issue.

For reference, `geos` computes the area of a polygon using unsigned areas of the rings, i.e. `abs(area_exterior) - sum(abs(area_interior_x))`. See: https://github.com/libgeos/geos/blob/master/src/geom/Polygon.cpp#L374. It may be worthwhile considering either moving to an unsigned area in `Geod` or offering an unsigned function as an option.
