### PR TITLE
PIN: shapely==1.7.0 due to missing windows wheels in 1.7.1

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,6 +7,6 @@ numpy
 pylint
 pytest>3.6
 pytest-cov
-shapely
+shapely==1.7.0
 pre-commit
 xarray


### PR DESCRIPTION
@mwtoews are you aware of the status of Shapely's Window's wheels?