### PR TITLE
LNT: Updates for isort 5

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,6 +1,5 @@
 [settings]
 line_length=88
 multi_line_output=3
-known_third_party=mock,numpy,pkg_resources,pytest,setuptools,xarray,pandas,certifi
 known_first_party=pyproj,test
 include_trailing_comma=true

--- a/Makefile
+++ b/Makefile
@@ -69,10 +69,10 @@ check-type:
 
 check: lint check-type ## flake8 black isort check
 	black --check setup.py pyproj/ test/ docs/
-	isort --check --recursive setup.py pyproj/ test/ docs/
+	isort --check setup.py pyproj/ test/ docs/
 
 isort: ## order imports
-	isort --recursive setup.py pyproj/ test/ docs/
+	isort setup.py pyproj/ test/ docs/
 
 black: ## black format files
 	black setup.py pyproj/ test/ docs/


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

https://pycqa.github.io/isort/docs/upgrade_guides/5.0.0/

```
Prior to version 5.0.0, isort wouldn't automatically traverse directories. The --recursive option was necessary to tell it to do so. In 5.0.0 directories are automatically traversed for all Python files, and as such this option is no longer necessary and should simply be removed.
```