### PR TITLE
Use unittest.mock from the standard library

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,6 @@
 cython>=0.28.4
 black
 flake8
-mock
 mypy
 numpy
 pylint

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -6,7 +6,7 @@ from glob import glob
 from pathlib import Path
 
 import pytest
-from mock import patch
+from unittest.mock import patch
 
 from pyproj.__main__ import main
 from pyproj.datadir import append_data_dir, get_data_dir, get_user_data_dir

--- a/test/test_datadir.py
+++ b/test/test_datadir.py
@@ -4,7 +4,7 @@ from contextlib import contextmanager
 from pathlib import Path
 
 import pytest
-from mock import patch
+from unittest.mock import patch
 
 import pyproj._datadir
 from pyproj import CRS, Transformer, get_codes, set_use_global_context

--- a/test/test_network.py
+++ b/test/test_network.py
@@ -1,6 +1,6 @@
 import certifi
 import pytest
-from mock import patch
+from unittest.mock import patch
 
 from pyproj.network import set_ca_bundle_path
 

--- a/test/test_proj.py
+++ b/test/test_proj.py
@@ -6,7 +6,7 @@ import unittest
 
 import numpy as np
 import pytest
-from mock import patch
+from unittest.mock import patch
 from numpy.testing import assert_almost_equal
 
 import pyproj

--- a/test/test_sync.py
+++ b/test/test_sync.py
@@ -2,7 +2,7 @@ from datetime import datetime, timedelta
 from urllib.error import URLError
 
 import pytest
-from mock import MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 from pyproj.aoi import BBox
 from pyproj.sync import (

--- a/test/test_transformer.py
+++ b/test/test_transformer.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 import numpy as np
 import pytest
-from mock import call, patch
+from unittest.mock import call, patch
 from numpy.testing import assert_almost_equal
 
 import pyproj


### PR DESCRIPTION
 - [ ] Fully documented, including `history.rst` for all changes and `api/*.rst` for new API

This PR replaces the external `mock` python package with `unittest.mock` from the standard library - and removes the requirement on `mock` external package.