### PR TITLE
DOC: Only include CLI page when building man pages 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -117,12 +117,11 @@ script:
   - python -c "import pyproj; pyproj.Proj('epsg:4269')"
   - make test-coverage
   - make check
-  - make docs-man
   # Building and uploading docs with doctr
   - set -e
   - |
     if [ "$DOC" ]; then
-      make install-docs
+      make docs-man
       make docs
       pip install doctr
       if [[ -z "$TRAVIS_TAG" ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -121,6 +121,7 @@ script:
   - set -e
   - |
     if [ "$DOC" ]; then
+      make install-docs
       make docs-man
       make docs
       pip install doctr

--- a/.travis.yml
+++ b/.travis.yml
@@ -117,6 +117,7 @@ script:
   - python -c "import pyproj; pyproj.Proj('epsg:4269')"
   - make test-coverage
   - make check
+  - make docs-man
   # Building and uploading docs with doctr
   - set -e
   - |

--- a/Makefile
+++ b/Makefile
@@ -96,6 +96,10 @@ docs: ## generate Sphinx HTML documentation, including API docs
 docs-browser: docs ## generate Sphinx HTML documentation, including API docs and open in a browser
 	$(BROWSER) docs/_build/html/index.html
 
+docs-man: ## generate Sphinx man pages for CLI
+	$(MAKE) -C docs clean
+	$(MAKE) -C docs man
+
 install: clean ## install the package to the active Python's site-packages
 	python setup.py install
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -140,7 +140,7 @@ latex_documents = [
 
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
-man_pages = [("cli", "pyproj", "pyproj Documentation", [author], 1)]
+man_pages = [("cli", "pyproj", "pyproj CLI", [author], 1)]
 
 
 # -- Options for Texinfo output ----------------------------------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -140,7 +140,7 @@ latex_documents = [
 
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
-man_pages = [(master_doc, "pyproj", "pyproj Documentation", [author], 1)]
+man_pages = [("cli", "pyproj", "pyproj Documentation", [author], 1)]
 
 
 # -- Options for Texinfo output ----------------------------------------


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Closes #735
 - [x] Tests added

@sebastic, you can build with:
```
cd docs/ && make man
```
and the file will be in `docs/_build/pyproj.1`
Mind trying it out?