### PR TITLE
DOC: Fix spelling errors

### DIFF
--- a/docs/advanced_examples.rst
+++ b/docs/advanced_examples.rst
@@ -44,10 +44,10 @@ Example with :class:`pyproj.transformer.Transformer`:
 Results: 6.32 µs ± 49.7 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)
 
 
-Tranforming with the same projections
+Transforming with the same projections
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-pyproj will skip transformations if they are exacly the same by default. However, if you
+pyproj will skip transformations if they are exactly the same by default. However, if you
 sometimes throw in the projections that are about the same and the results being close enough
 is what you want, the `skip_equivalent` option can help.
 

--- a/docs/build_crs.rst
+++ b/docs/build_crs.rst
@@ -44,7 +44,7 @@ PROJ string::
     geog_wkt = geog_crs.to_wkt()
 
 
-This example is meant to show off different intialization methods.
+This example is meant to show off different initialization methods.
 It can be simplified to not use the Ellipsoid or PrimeMeridian objects.
 
 PROJ string::

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -48,7 +48,7 @@ Change Log
 * ENH: Updated :attr:`pyproj.crs.CRS.axis_info` to pull all relevant axis information from CRS (issue #557)
 * ENH: Added :meth:`pyproj.transformer.Transform.__eq__` (issue #559)
 * ENH: Added :attr:`pyproj.crs.CRS.utm_zone` (issue #561)
-* BUG: Modify CRS dict test to accomodate numpy bool types. (issue #564)
+* BUG: Modify CRS dict test to accommodate numpy bool types. (issue #564)
 * BUG: Fix pipeline transformations to match cct (issue #565)
 * BUG: Don't silently ignore kwargs when projparams are specified (Proj & CRS) (issue #565)
 
@@ -70,7 +70,7 @@ Change Log
 ~~~~~
 * Elevate +init= warning to FutureWarning (pull #486)
 * Add UserWarning to :meth:`pyproj.crs.CRS.to_proj4` (pull #486)
-* BUG: Fix for 32-bit i686 plaforms (issue #481)
+* BUG: Fix for 32-bit i686 platforms (issue #481)
 * Return 'inf' in Proj instead of 1.e30 (pull #491)
 
 2.4.1
@@ -191,7 +191,7 @@ Change Log
 2.1.2
 ~~~~~
 * Updated to use the CRS definition for Proj instances in transforms (issue #207)
-* Add option to skip tranformation operation if input and output projections are equivalent
+* Add option to skip transformation operation if input and output projections are equivalent
   and always skip if the input and output projections are exact (issue #128)
 * Update setup.py method for checking PROJ version (pull #211)
 * Add internal proj error log messages to exceptions (pull #215)

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -95,7 +95,7 @@ pyproj Build Environment Variables
 
 .. envvar:: PROJ_LIBDIR
 
-    This is the path to the directory contaning the PROJ libraries.
+    This is the path to the directory containing the PROJ libraries.
     If not set, it searches the `lib` and `lib64` directories inside
     the PROJ directory.
 
@@ -106,7 +106,7 @@ pyproj Build Environment Variables
 
 .. envvar:: PROJ_WHEEL
 
-    This is a boolean value used when bulding a wheel. When true
+    This is a boolean value used when building a wheel. When true
     it includes the contents of the `pyproj/proj_dir/proj/share`
     directory if present.
 

--- a/pyproj/_crs.pyx
+++ b/pyproj/_crs.pyx
@@ -811,7 +811,7 @@ cdef class Ellipsoid(_CRSParts):
         Parameters
         ----------
         auth_name: str
-            Name ot the authority.
+            Name of the authority.
         code: str or int
             The code used by the authority.
 
@@ -1089,7 +1089,7 @@ cdef class PrimeMeridian(_CRSParts):
         Parameters
         ----------
         auth_name: str
-            Name ot the authority.
+            Name of the authority.
         code: str or int
             The code used by the authority.
 
@@ -1336,7 +1336,7 @@ cdef class Datum(_CRSParts):
         Parameters
         ----------
         auth_name: str
-            Name ot the authority.
+            Name of the authority.
         code: str or int
             The code used by the authority.
 
@@ -1369,7 +1369,7 @@ cdef class Datum(_CRSParts):
         Parameters
         ----------
         auth_name: str
-            Name ot the authority.
+            Name of the authority.
         code: str or int
             The code used by the authority.
 
@@ -1916,7 +1916,7 @@ cdef class CoordinateOperation(_CRSParts):
         Parameters
         ----------
         auth_name: str
-            Name ot the authority.
+            Name of the authority.
         code: str or int
             The code used by the authority.
         use_proj_alternative_grid_names: bool, optional

--- a/pyproj/sync.py
+++ b/pyproj/sync.py
@@ -232,7 +232,7 @@ def get_transform_grid_list(
     include_world_coverage: bool, optional
         Defaults to True.
     include_already_downloaded: bool, optional
-        If True, it will list grids reguardless of if they are downloaded.
+        If True, it will list grids regardless of if they are downloaded.
         Defaults to False.
     target_directory: Union[str, Path], optional
         The directory to download the geojson file to.


### PR DESCRIPTION
The lintian QA tool reported several spelling errors for the Debian package build:

 * Tranforming   -> Transforming
 * accomodate    -> accommodate
 * bulding       -> building
 * contaning     -> containing
 * exacly        -> exactly
 * intialization -> initialization
 * plaforms      -> platforms
 * reguardless   -> regardless
 * tranformation -> transformation
 * ot            -> of
