### PR TITLE
Delete .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,0 @@
-proj.4/src/* linguist-vendored
-nad2bin.c linguist-vendored


### PR DESCRIPTION
This file is a a relic from when PROJ's code (vendor code) was in the pyproj repo.  Github's linguist had to be told to ignore that code when calculating the amount of Python versus C code for it percent Language in the repo (PROJ dwarfs pyproj in lines of code).
