### PR TITLE
Use proj_context_errno_string in PROJ 8+ due to deprecation

### DIFF
--- a/docs/history.rst
+++ b/docs/history.rst
@@ -3,6 +3,7 @@ Change Log
 
 3.0.1
 -----
+* Use `proj_context_errno_string` in PROJ 8+ due to deprecation (issue #760)
 
 3.0.0
 -----

--- a/pyproj/_transformer.pyx
+++ b/pyproj/_transformer.pyx
@@ -25,6 +25,14 @@ from pyproj.exceptions import ProjError
 proj_version_str = f"{PROJ_VERSION_MAJOR}.{PROJ_VERSION_MINOR}.{PROJ_VERSION_PATCH}"
 
 
+cdef pyproj_errno_string(PJ_CONTEXT* ctx, int err):
+    # https://github.com/pyproj4/pyproj/issues/760
+    IF CTE_PROJ_VERSION_MAJOR >= 8:
+        return pystrdecode(proj_context_errno_string(ctx, err))
+    ELSE:
+        return pystrdecode(proj_errno_string(err))
+
+
 _PJ_DIRECTION_MAP = {
     TransformDirection.FORWARD: PJ_FWD,
     TransformDirection.INVERSE: PJ_INV,
@@ -503,7 +511,7 @@ cdef class _Transformer(Base):
             if errcheck and errno:
                 with gil:
                     raise ProjError(
-                        f"transform error: {pystrdecode(proj_errno_string(errno))}"
+                        f"transform error: {pyproj_errno_string(self.context, errno)}"
                     )
             elif errcheck:
                 with gil:
@@ -601,7 +609,7 @@ cdef class _Transformer(Base):
             if errcheck and errno:
                 with gil:
                     raise ProjError(
-                        f"itransform error: {pystrdecode(proj_errno_string(errno))}"
+                        f"itransform error: {pyproj_errno_string(self.context, errno)}"
                     )
             elif errcheck:
                 with gil:
@@ -701,7 +709,7 @@ cdef class _Transformer(Base):
                 if errcheck and errno:
                     with gil:
                         raise ProjError(
-                            f"proj error: {pystrdecode(proj_errno_string(errno))}"
+                            f"proj error: {pyproj_errno_string(self.context, errno)}"
                         )
 
                 if errno or invalid_coord:

--- a/pyproj/proj.pxi
+++ b/pyproj/proj.pxi
@@ -2,6 +2,7 @@
 
 IF CTE_PROJ_VERSION_MAJOR >= 8:
     cdef extern from "proj.h":
+        const char * proj_context_errno_string(PJ_CONTEXT* ctx, int err)
         ctypedef enum PJ_CATEGORY:
             PJ_CATEGORY_ELLIPSOID
             PJ_CATEGORY_PRIME_MERIDIAN
@@ -11,6 +12,7 @@ IF CTE_PROJ_VERSION_MAJOR >= 8:
             PJ_CATEGORY_DATUM_ENSEMBLE
 ELSE:
     cdef extern from "proj.h":
+        const char * proj_errno_string(int err)
         ctypedef enum PJ_CATEGORY:
             PJ_CATEGORY_ELLIPSOID
             PJ_CATEGORY_PRIME_MERIDIAN
@@ -51,7 +53,6 @@ cdef extern from "proj.h":
 
     int proj_errno (const PJ *P) nogil
     int proj_context_errno (PJ_CONTEXT *ctx)
-    const char * proj_errno_string (int err)
     int  proj_errno_reset (const PJ *P) nogil
     PJ *proj_create (PJ_CONTEXT *ctx, const char *definition)
     PJ *proj_normalize_for_visualization(PJ_CONTEXT *ctx, const PJ* obj)


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Closes #760
 - [x] Fully documented, including `history.rst` for all changes and `api/*.rst` for new API
