### PR TITLE
DOC: pin sphinx < 3.5.0

### DIFF
--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,3 +1,3 @@
-sphinx
+sphinx < 3.5.0
 sphinx_rtd_theme
 sphinx-argparse


### PR DESCRIPTION
3.5.0 released yesterday throwing errors [ref](https://github.com/pyproj4/pyproj/runs/1907433564?check_suite_focus=true)
```
Extension error (sphinx.ext.viewcode):
Handler <function env_purge_doc at 0x7fb608fe5700> for event 'env-purge-doc' threw an exception (exception: cannot unpack non-iterable bool object)
```