### PR TITLE
BUG: Skip noop transformations since they always return False for proj_degree_input

### DIFF
--- a/pyproj/_transformer.pyx
+++ b/pyproj/_transformer.pyx
@@ -761,6 +761,7 @@ cdef class _Transformer(Base):
         if (
             self.projections_exact_same
             or (self.projections_equivalent and self.skip_equivalent)
+            or self.id == "noop"
         ):
             return
 
@@ -855,6 +856,7 @@ cdef class _Transformer(Base):
         if (
             self.projections_exact_same
             or (self.projections_equivalent and self.skip_equivalent)
+            or self.id == "noop"
         ):
             return
         tmp_pj_direction = _PJ_DIRECTION_MAP[TransformDirection.create(direction)]
@@ -957,8 +959,9 @@ cdef class _Transformer(Base):
         if (
             self.projections_exact_same
             or (self.projections_equivalent and self.skip_equivalent)
+            or self.id == "noop"
         ):
-            return
+            return (left, bottom, right, top)
 
         if densify_pts < 0:
             raise ProjError("densify_pts must be positive")

--- a/test/test_transformer.py
+++ b/test/test_transformer.py
@@ -1376,3 +1376,12 @@ def test_transform_bounds__ignore_inf(input_crs, expected_bounds):
         expected_bounds,
         decimal=0,
     )
+
+
+def test_transform_bounds__noop_geographic():
+    crs = CRS("Pulkovo 1942")
+    transformer = Transformer.from_crs(crs.geodetic_crs, crs, always_xy=True)
+    assert_almost_equal(
+        transformer.transform_bounds(*crs.area_of_use.bounds),
+        crs.area_of_use.bounds,
+    )


### PR DESCRIPTION
Discovered this when investigating https://github.com/OSGeo/PROJ/pull/2654

`proj_degree_input/output` and `proj_angular_output/output` all returned false.

Also, added return of input bounds when this occurs.