### PR TITLE
REF: Skip transformations if 'noop' & deprecate 'skip_equivalent'

### DIFF
--- a/docs/advanced_examples.rst
+++ b/docs/advanced_examples.rst
@@ -47,14 +47,8 @@ Results: 6.32 µs ± 49.7 ns per loop (mean ± std. dev. of 7 runs, 100000 loops
 Transforming with the same projections
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-pyproj will skip transformations if they are exactly the same by default. However, if you
-sometimes throw in the projections that are about the same and the results being close enough
-is what you want, the `skip_equivalent` option can help.
+pyproj skips `noop` transformations.
 
-.. note:: From PROJ code: The objects are equivalent for the purpose of coordinate operations.
-    They can differ by the name of their objects, identifiers, other metadata.
-    Parameters may be expressed in different units, provided that the value is
-    (with some tolerance) the same once expressed in a common unit.
 
 Transformation Group
 --------------------

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -13,6 +13,7 @@ Change Log
 * ENH: Added :meth:`pyproj.crs.CRS.to_3d` (pull #808)
 * ENH: Added :meth:`pyproj.transformer.Transformer.transform_bounds` (issue #809)
 * ENH: Added :attr:`pyproj.crs.CRS.is_compound` (pull #823)
+* REF: Skip transformations if `noop` & deprecate `skip_equivalent` (pull #824)
 
 3.0.1
 -----

--- a/pyproj/_transformer.pxd
+++ b/pyproj/_transformer.pxd
@@ -12,9 +12,6 @@ cdef class _TransformerGroup:
 cdef class _Transformer(Base):
     cdef PJ_PROJ_INFO proj_info
     cdef readonly _area_of_use
-    cdef readonly skip_equivalent
-    cdef readonly projections_equivalent
-    cdef readonly projections_exact_same
     cdef readonly type_name
     cdef readonly object _operations
 
@@ -22,8 +19,5 @@ cdef class _Transformer(Base):
     cdef _Transformer _from_pj(
         PJ_CONTEXT* context,
         PJ *transform_pj,
-        _CRS crs_from,
-        _CRS crs_to,
-        skip_equivalent,
         always_xy,
     )

--- a/pyproj/_transformer.pyi
+++ b/pyproj/_transformer.pyi
@@ -32,9 +32,8 @@ class _TransformerGroup:
     _best_available: bool
     def __init__(
         self,
-        crs_from: _CRS,
-        crs_to: _CRS,
-        skip_equivalent: bool = False,
+        crs_from: str,
+        crs_to: str,
         always_xy: bool = False,
         area_of_interest: Optional[AreaOfInterest] = None,
     ) -> None: ...
@@ -43,9 +42,6 @@ class _Transformer(Base):
     input_geographic: bool
     output_geographic: bool
     is_pipeline: bool
-    skip_equivalent: bool
-    projections_equivalent: bool
-    projections_exact_same: bool
     type_name: str
     @property
     def id(self) -> str: ...
@@ -70,9 +66,8 @@ class _Transformer(Base):
     ) -> str: ...
     @staticmethod
     def from_crs(
-        crs_from: _CRS,
-        crs_to: _CRS,
-        skip_equivalent: bool = False,
+        crs_from: str,
+        crs_to: str,
         always_xy: bool = False,
         area_of_interest: Optional[AreaOfInterest] = None,
         authority: Optional[str] = None,

--- a/test/test_transformer.py
+++ b/test/test_transformer.py
@@ -78,61 +78,20 @@ def test_lambert_conformal_transform():
 
 
 def test_equivalent_crs():
-    transformer = Transformer.from_crs("epsg:4326", 4326, skip_equivalent=True)
-    assert transformer._transformer.projections_equivalent
-    assert transformer._transformer.projections_exact_same
-    assert transformer._transformer.skip_equivalent
-
-
-def test_equivalent_crs__disabled():
-    transformer = Transformer.from_crs("epsg:4326", 4326)
-    assert not transformer._transformer.skip_equivalent
-    assert transformer._transformer.projections_equivalent
-    assert transformer._transformer.projections_exact_same
-
-
-def test_equivalent_crs__different():
-    transformer = Transformer.from_crs("epsg:4326", 3857, skip_equivalent=True)
-    assert transformer._transformer.skip_equivalent
-    assert not transformer._transformer.projections_equivalent
-    assert not transformer._transformer.projections_exact_same
+    with pytest.warns(DeprecationWarning):
+        Transformer.from_crs("epsg:4326", 4326, skip_equivalent=True)
 
 
 def test_equivalent_proj():
-    with pytest.warns(UserWarning):
-        proj_to = pyproj.Proj(4326).crs.to_proj4()
     with pytest.warns(FutureWarning):
-        transformer = Transformer.from_proj(
-            "+init=epsg:4326", proj_to, skip_equivalent=True
-        )
-    assert transformer._transformer.skip_equivalent
-    assert transformer._transformer.projections_equivalent
-    assert not transformer._transformer.projections_exact_same
+        proj_from = pyproj.Proj("+init=epsg:4326")
+    with pytest.warns(DeprecationWarning):
+        Transformer.from_proj(proj_from, 4326, skip_equivalent=True)
 
 
-def test_equivalent_proj__disabled():
-    with pytest.warns(UserWarning):
-        transformer = Transformer.from_proj(3857, pyproj.Proj(3857).crs.to_proj4())
-    assert not transformer._transformer.skip_equivalent
-    assert transformer._transformer.projections_equivalent
-    assert not transformer._transformer.projections_exact_same
-
-
-def test_equivalent_proj__different():
-    transformer = Transformer.from_proj(3857, 4326, skip_equivalent=True)
-    assert transformer._transformer.skip_equivalent
-    assert not transformer._transformer.projections_equivalent
-    assert not transformer._transformer.projections_exact_same
-
-
-def test_equivalent_pipeline():
-    transformer = Transformer.from_pipeline(
-        "+proj=pipeline +step +proj=longlat +ellps=WGS84 +step "
-        "+proj=unitconvert +xy_in=rad +xy_out=deg"
-    )
-    assert not transformer._transformer.skip_equivalent
-    assert not transformer._transformer.projections_equivalent
-    assert not transformer._transformer.projections_exact_same
+def test_equivalent_transformer_group():
+    with pytest.warns(DeprecationWarning):
+        TransformerGroup("epsg:4326", 4326, skip_equivalent=True)
 
 
 def test_4d_transform():


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Tests added
 - [x] Fully documented, including `history.rst` for all changes and `api/*.rst` for new API

Skip equivalent/exact same is not needed. This means that one less CRS object is needed when re-creating `_Transformer` across threads.

```python
>>> from pyproj import CRS, Transformer
>>> crs = CRS(4326)
>>> tr = Transformer.from_crs(crs.to_proj4(), "+init=epsg:4326")
>>> tr.name
'noop'
>>> CRS(crs.to_proj4()) == "+init=epsg:4326"
True
>>> CRS(crs.to_proj4()).is_exact_same("+init=epsg:4326")
False
```

