### PR TITLE
REF: Update pyproj.Geod.npts to use geod_inverseline

### DIFF
--- a/docs/history.rst
+++ b/docs/history.rst
@@ -14,6 +14,7 @@ Change Log
 * ENH: Added :meth:`pyproj.transformer.Transformer.transform_bounds` (issue #809)
 * ENH: Added :attr:`pyproj.crs.CRS.is_compound` (pull #823)
 * REF: Skip transformations if `noop` & deprecate `skip_equivalent` (pull #824)
+* REF: Update :meth:`pyproj.Geod.npts` to use `geod_inverseline` (pull #825)
 
 3.0.1
 -----

--- a/pyproj/_geod.pxd
+++ b/pyproj/_geod.pxd
@@ -2,7 +2,17 @@ cdef extern from "geodesic.h":
     struct geod_geodesic:
         pass
     struct geod_geodesicline:
-        pass
+        double lat1
+        double lon1
+        double azi1
+        double a
+        double f
+        double salp1
+        double calp1
+        double a13
+        double s13
+        unsigned caps
+
     void geod_init(geod_geodesic* g, double a, double f)
     void geod_direct(
         geod_geodesic* g,
@@ -22,12 +32,13 @@ cdef extern from "geodesic.h":
         double* ps12,
         double* pazi1,
         double* pazi2) nogil
-    void geod_lineinit(
+    void geod_inverseline(
         geod_geodesicline* l,
-        geod_geodesic* g,
+        const geod_geodesic* g,
         double lat1,
         double lon1,
-        double azi1,
+        double lat2,
+        double lon2,
         unsigned caps) nogil
     void geod_position(
         geod_geodesicline* l,


### PR DESCRIPTION
Noticed this note and figured it was safe to update:
```
# in proj 4.9.3 and later the next two steps can be replace by a call
# to geod_inverseline with del_s = line.s13/(npts+1)
```
