### PR TITLE
add `[inv|fwd]_intermediate()` - to calculate intermediate points (like improved `Geod.npts()`)

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -430,6 +430,18 @@
       "contributions": [
         "platform"
       ]
+    },
+    {
+      "login": "idanmiara",
+      "name": "Idan Miara",
+      "avatar_url": "https://avatars.githubusercontent.com/u/26349741?v=4",
+      "profile": "https://github.com/idanmiara",
+      "contributions": [
+        "code",
+        "doc",
+        "example",
+        "test"
+      ]
     }
   ],
   "contributorsPerLine": 7

--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
     <td align="center"><a href="https://rahulporuri.github.io"><img src="https://avatars0.githubusercontent.com/u/1926457?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Poruri Sai Rahul</b></sub></a><br /><a href="https://github.com/pyproj4/pyproj/commits?author=rahulporuri" title="Tests">⚠️</a></td>
     <td align="center"><a href="https://medium.com/@underchemist"><img src="https://avatars1.githubusercontent.com/u/5283998?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Yann-Sebastien Tremblay-Johnston</b></sub></a><br /><a href="https://github.com/pyproj4/pyproj/commits?author=underchemist" title="Documentation">📖</a></td>
     <td align="center"><a href="https://github.com/odidev"><img src="https://avatars2.githubusercontent.com/u/40816837?v=4?s=100" width="100px;" alt=""/><br /><sub><b>odidev</b></sub></a><br /><a href="#platform-odidev" title="Packaging/porting to new platform">📦</a></td>
+    <td align="center"><a href="https://github.com/idanmiara"><img src="https://avatars.githubusercontent.com/u/26349741?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Idan Miara</b></sub></a><br /><a href="https://github.com/pyproj4/pyproj/commits?author=idanmiara" title="Code">💻</a> <a href="https://github.com/pyproj4/pyproj/commits?author=idanmiara" title="Documentation">📖</a> <a href="#example-idanmiara" title="Examples">💡</a> <a href="https://github.com/pyproj4/pyproj/commits?author=idanmiara" title="Tests">⚠️</a></td>
   </tr>
 </table>
 

--- a/docs/api/enums.rst
+++ b/docs/api/enums.rst
@@ -15,3 +15,6 @@ Enumerations
 
 .. autoclass:: pyproj.enums.PJType
     :members:
+
+.. autoclass:: pyproj.enums.GeodIntermediateFlag
+    :members:

--- a/docs/api/geod.rst
+++ b/docs/api/geod.rst
@@ -9,3 +9,6 @@ pyproj.Geod
     :show-inheritance:
     :inherited-members:
     :special-members: __init__
+
+.. autoclass:: pyproj.geod.GeodIntermediateReturn
+    :members:

--- a/pyproj/_geod.pxd
+++ b/pyproj/_geod.pxd
@@ -32,6 +32,13 @@ cdef extern from "geodesic.h":
         double* ps12,
         double* pazi1,
         double* pazi2) nogil
+    void geod_lineinit(
+        geod_geodesicline* l,
+        const geod_geodesic* g,
+        double lat1,
+        double lon1,
+        double azi1,
+        unsigned caps) nogil
     void geod_inverseline(
         geod_geodesicline* l,
         const geod_geodesic* g,

--- a/pyproj/_geod.pyi
+++ b/pyproj/_geod.pyi
@@ -28,17 +28,6 @@ class Geod:
     def _inv(
         self, lons1: Any, lats1: Any, lons2: Any, lats2: Any, radians: bool = False
     ) -> None: ...
-    def _npts(
-        self,
-        lon1: float,
-        lat1: float,
-        lon2: float,
-        lat2: float,
-        npts: int,
-        radians: bool = False,
-        initial_idx: int = 1,
-        terminus_idx: int = 1,
-    ) -> Tuple[Tuple[float], Tuple[float]]: ...
     def _inv_or_fwd_intermediate(
         self,
         lon1: float,

--- a/pyproj/_geod.pyi
+++ b/pyproj/_geod.pyi
@@ -31,6 +31,20 @@ class Geod:
         initial_idx: int = 1,
         terminus_idx: int = 1,
     ) -> Tuple[Tuple[float], Tuple[float]]: ...
+    def _inv_intermediate(
+        self,
+        out_lons: Any,
+        out_lats: Any,
+        out_azis: Any,
+        lon1: float,
+        lat1: float,
+        lon2: float,
+        lat2: float,
+        npts: int,
+        radians: bool = False,
+        initial_idx: int = 1,
+        terminus_idx: int = 1,
+    ) -> int: ...
     def _line_length(self, lons: Any, lats: Any, radians: bool = False) -> float: ...
     def _polygon_area_perimeter(
         self, lons: Any, lats: Any, radians: bool = False

--- a/pyproj/_geod.pyi
+++ b/pyproj/_geod.pyi
@@ -1,6 +1,14 @@
-from typing import Any, Tuple, Type
+from typing import Any, NamedTuple, Tuple, Type
 
 geodesic_version_str: str
+
+class GeodIntermediateReturn(NamedTuple):
+    npts: int
+    del_s: float
+    dist: float
+    lons: Any
+    lats: Any
+    azis: Any
 
 class Geod:
     initstring: str
@@ -31,20 +39,22 @@ class Geod:
         initial_idx: int = 1,
         terminus_idx: int = 1,
     ) -> Tuple[Tuple[float], Tuple[float]]: ...
-    def _inv_intermediate(
+    def _inv_or_fwd_intermediate(
         self,
+        lon1: float,
+        lat1: float,
+        lon2_or_azi1: float,
+        lat2_or_nan: float,
+        npts: int,
+        del_s: float,
+        radians: bool,
+        initial_idx: int,
+        terminus_idx: int,
+        flags: int,
         out_lons: Any,
         out_lats: Any,
         out_azis: Any,
-        lon1: float,
-        lat1: float,
-        lon2: float,
-        lat2: float,
-        npts: int,
-        radians: bool = False,
-        initial_idx: int = 1,
-        terminus_idx: int = 1,
-    ) -> int: ...
+    ) -> GeodIntermediateReturn: ...
     def _line_length(self, lons: Any, lats: Any, radians: bool = False) -> float: ...
     def _polygon_area_perimeter(
         self, lons: Any, lats: Any, radians: bool = False

--- a/pyproj/_geod.pyi
+++ b/pyproj/_geod.pyi
@@ -28,6 +28,8 @@ class Geod:
         lat2: float,
         npts: int,
         radians: bool = False,
+        initial_idx: int = 1,
+        terminus_idx: int = 1,
     ) -> Tuple[Tuple[float], Tuple[float]]: ...
     def _line_length(self, lons: Any, lats: Any, radians: bool = False) -> float: ...
     def _polygon_area_perimeter(

--- a/pyproj/_geod.pyx
+++ b/pyproj/_geod.pyx
@@ -199,42 +199,6 @@ cdef class Geod:
 
     @cython.boundscheck(False)
     @cython.wraparound(False)
-    def _npts(
-        self,
-        double lon1,
-        double lat1,
-        double lon2,
-        double lat2,
-        int npts,
-        bint radians=False,
-        int initial_idx=1,
-        int terminus_idx=1,
-    ):
-        """
-        given initial and terminus lat/lon, find npts intermediate points.
-        returns lons, lats buffers
-        """
-        res = \
-            self._inv_or_fwd_intermediate(
-                lon1=lon1,
-                lat1=lat1,
-                lon2_or_azi1=lon2,
-                lat2_or_nan=lat2,
-                npts=npts,
-                del_s=0,
-                radians=radians,
-                initial_idx=initial_idx,
-                terminus_idx=terminus_idx,
-                flags = GEOD_INTER_FLAG_AZIS_DISCARD,
-                out_lons=None,
-                out_lats=None,
-                out_azis=None,
-            )
-
-        return res.lons, res.lats
-
-    @cython.boundscheck(False)
-    @cython.wraparound(False)
     def _inv_or_fwd_intermediate(
         self,
         double lon1,

--- a/pyproj/enums.py
+++ b/pyproj/enums.py
@@ -1,7 +1,7 @@
 """
 This module contains enumerations used in pyproj.
 """
-from enum import Enum
+from enum import Enum, IntFlag
 
 
 class BaseEnum(Enum):
@@ -136,3 +136,26 @@ class PJType(BaseEnum):
     TRANSFORMATION = "TRANSFORMATION"
     CONCATENATED_OPERATION = "CONCATENATED_OPERATION"
     OTHER_COORDINATE_OPERATION = "OTHER_COORDINATE_OPERATION"
+
+
+class GeodIntermediateFlag(IntFlag):
+    """
+    .. versionadded:: 3.1.0
+
+    Flags to be used in Geod.[inv|fwd]_intermediate()
+    """
+
+    DEFAULT = 0x0
+
+    NPTS_MASK = 0xF
+    NPTS_ROUND = 0x0
+    NPTS_CEIL = 0x1
+    NPTS_TRUNC = 0x2
+
+    DEL_S_MASK = 0xF0
+    DEL_S_RECALC = 0x00
+    DEL_S_NO_RECALC = 0x10
+
+    AZIS_MASK = 0xF00
+    AZIS_DISCARD = 0x000
+    AZIS_KEEP = 0x100

--- a/pyproj/geod.py
+++ b/pyproj/geod.py
@@ -365,6 +365,38 @@ class Geod(_Geod):
         )
         return list(zip(lons, lats))
 
+    def inv_intermediate(
+        self,
+        out_lons: Any,
+        out_lats: Any,
+        out_azis: Any,
+        lon1: float,
+        lat1: float,
+        lon2: float,
+        lat2: float,
+        npts: int,
+        initial_idx: int = 1,
+        terminus_idx: int = 1,
+        radians: bool = False,
+    ) -> None:
+        """
+        Similar to npts(), but using the given buffers for the output.
+        out_lons, out_lats, and out_az are the output buffers (out_azis is optional)
+        """
+        super()._inv_intermediate(
+            out_lons=out_lons,
+            out_lats=out_lats,
+            out_azis=out_azis,
+            lon1=lon1,
+            lat1=lat1,
+            lon2=lon2,
+            lat2=lat2,
+            npts=npts,
+            radians=radians,
+            initial_idx=initial_idx,
+            terminus_idx=terminus_idx,
+        )
+
     def line_length(self, lons: Any, lats: Any, radians: bool = False) -> float:
         """
         .. versionadded:: 2.3.0

--- a/pyproj/geod.py
+++ b/pyproj/geod.py
@@ -364,17 +364,23 @@ class Geod(_Geod):
             list of (lon, lat) points along the geodesic
             between the initial and terminus points.
         """
-        lons, lats = super()._npts(
-            lon1,
-            lat1,
-            lon2,
-            lat2,
-            npts,
+
+        res = self._inv_or_fwd_intermediate(
+            lon1=lon1,
+            lat1=lat1,
+            lon2_or_azi1=lon2,
+            lat2_or_nan=lat2,
+            npts=npts,
+            del_s=0,
             radians=radians,
             initial_idx=initial_idx,
             terminus_idx=terminus_idx,
+            flags=GeodIntermediateFlag.AZIS_DISCARD,
+            out_lons=None,
+            out_lats=None,
+            out_azis=None,
         )
-        return list(zip(lons, lats))
+        return list(zip(res.lons, res.lats))
 
     def inv_intermediate(
         self,

--- a/pyproj/geod.py
+++ b/pyproj/geod.py
@@ -273,6 +273,8 @@ class Geod(_Geod):
         lat2: float,
         npts: int,
         radians: bool = False,
+        initial_idx: int = 1,
+        terminus_idx: int = 1,
     ) -> List:
         """
         Given a single initial point and terminus point, returns
@@ -336,16 +338,31 @@ class Geod(_Geod):
             Latitude of the terminus point
         npts: int
             Number of points to be returned
+            (including initial and/or terminus points, if required)
         radians: bool, optional
             If True, the input data is assumed to be in radians.
-
+        initial_idx: int, optional
+            if initial_idx==0 then the initial point would be included in the output
+            (as the first point)
+        terminus_idx: int, optional
+            if terminus_idx==0 then the terminus point would be included in the output
+            (as the last point)
         Returns
         -------
         list of tuples:
             list of (lon, lat) points along the geodesic
             between the initial and terminus points.
         """
-        lons, lats = super()._npts(lon1, lat1, lon2, lat2, npts, radians=radians)
+        lons, lats = super()._npts(
+            lon1,
+            lat1,
+            lon2,
+            lat2,
+            npts,
+            radians=radians,
+            initial_idx=initial_idx,
+            terminus_idx=terminus_idx,
+        )
         return list(zip(lons, lats))
 
     def line_length(self, lons: Any, lats: Any, radians: bool = False) -> float:

--- a/pyproj/geod.py
+++ b/pyproj/geod.py
@@ -8,13 +8,20 @@ determining the forward and back azimuths and distance given the
 latitudes and longitudes of an initial and terminus point.
 """
 
-__all__ = ["Geod", "pj_ellps", "geodesic_version_str"]
+__all__ = [
+    "Geod",
+    "pj_ellps",
+    "geodesic_version_str",
+    "GeodIntermediateFlag",
+    "GeodIntermediateReturn",
+]
 
 import math
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 from pyproj._geod import Geod as _Geod
-from pyproj._geod import geodesic_version_str
+from pyproj._geod import GeodIntermediateReturn, geodesic_version_str
+from pyproj.enums import GeodIntermediateFlag
 from pyproj.exceptions import GeodError
 from pyproj.list import get_ellps_map
 from pyproj.utils import _convertback, _copytobuffer
@@ -277,10 +284,14 @@ class Geod(_Geod):
         terminus_idx: int = 1,
     ) -> List:
         """
+        .. versionadded:: 3.1.0 initial_idx, terminus_idx
+
         Given a single initial point and terminus point, returns
         a list of longitude/latitude pairs describing npts equally
         spaced intermediate points along the geodesic between the
         initial and terminus points.
+
+        Similar to inv_intermediate(), but with less options.
 
         Example usage:
 
@@ -367,34 +378,276 @@ class Geod(_Geod):
 
     def inv_intermediate(
         self,
-        out_lons: Any,
-        out_lats: Any,
-        out_azis: Any,
         lon1: float,
         lat1: float,
         lon2: float,
         lat2: float,
-        npts: int,
+        npts: int = 0,
+        del_s: float = 0,
         initial_idx: int = 1,
         terminus_idx: int = 1,
         radians: bool = False,
-    ) -> None:
+        flags: GeodIntermediateFlag = GeodIntermediateFlag.DEFAULT,
+        out_lons: Any = None,
+        out_lats: Any = None,
+        out_azis: Any = None,
+    ) -> GeodIntermediateReturn:
         """
-        Similar to npts(), but using the given buffers for the output.
-        out_lons, out_lats, and out_az are the output buffers (out_azis is optional)
+        .. versionadded:: 3.1.0
+
+        Given a single initial point and terminus point,
+        and the number of points, returns
+        a list of longitude/latitude pairs describing npts equally
+        spaced intermediate points along the geodesic between the
+        initial and terminus points.
+
+        npts and del_s parameters are mutually exclusive:
+
+        if npts != 0:
+            it calculates the distance between the points by
+            the distance between the initial point and the
+            terminus point divided by npts
+            (the number of intermediate points)
+        else:
+            it calculates the number of intermediate points by
+            dividing the distance between the initial and
+            terminus points by del_s
+            (delimiter distance between two successive points)
+
+        Similar to npts(), but with more options.
+
+        Example usage:
+
+        >>> from pyproj import Geod
+        >>> g = Geod(ellps='clrk66') # Use Clarke 1866 ellipsoid.
+        >>> # specify the lat/lons of Boston and Portland.
+        >>> boston_lat = 42.+(15./60.); boston_lon = -71.-(7./60.)
+        >>> portland_lat = 45.+(31./60.); portland_lon = -123.-(41./60.)
+        >>> # find ten equally spaced points between Boston and Portland.
+        >>> r = g.inv_intermediate(boston_lon,boston_lat,portland_lon,portland_lat,10)
+        >>> for lon,lat in zip(r.lons, r.lats): f'{lat:.3f} {lon:.3f}'
+        '43.528 -75.414'
+        '44.637 -79.883'
+        '45.565 -84.512'
+        '46.299 -89.279'
+        '46.830 -94.156'
+        '47.149 -99.112'
+        '47.251 -104.106'
+        '47.136 -109.100'
+        '46.805 -114.051'
+        '46.262 -118.924'
+        >>> # test with radians=True (inputs/outputs in radians, not degrees)
+        >>> import math
+        >>> dg2rad = math.radians(1.)
+        >>> rad2dg = math.degrees(1.)
+        >>> r = g.inv_intermediate(
+        ...    dg2rad*boston_lon,
+        ...    dg2rad*boston_lat,
+        ...    dg2rad*portland_lon,
+        ...    dg2rad*portland_lat,
+        ...    10,
+        ...    radians=True
+        ... )
+        >>> for lon,lat in zip(r.lons, r.lats): f'{rad2dg*lat:.3f} {rad2dg*lon:.3f}'
+        '43.528 -75.414'
+        '44.637 -79.883'
+        '45.565 -84.512'
+        '46.299 -89.279'
+        '46.830 -94.156'
+        '47.149 -99.112'
+        '47.251 -104.106'
+        '47.136 -109.100'
+        '46.805 -114.051'
+        '46.262 -118.924'
+
+        Parameters
+        ----------
+        lon1: float
+            Longitude of the initial point
+        lat1: float
+            Latitude of the initial point
+        lon2: float
+            Longitude of the terminus point
+        lat2: float
+            Latitude of the terminus point
+        npts: int, optional
+            Number of points to be returned
+            npts == 0 iff del_s != 0
+        del_s: float, optional
+            delimiter distance between two successive points
+            del_s == 0 iff npts != 0
+        radians: bool, optional
+            If True, the input data is assumed to be in radians.
+        initial_idx: int, optional
+            if initial_idx==0 then the initial point would be included in the output
+            (as the first point)
+        terminus_idx: int, optional
+            if terminus_idx==0 then the terminus point would be included in the output
+            (as the last point)
+        flags: GeodIntermediateFlag, optional
+            1st: round/ceil/trunc (see GeodIntermediateFlag.NPTS_*)
+            2nd: update del_s to the new npts or not (see GeodIntermediateFlag.DEL_S_*)
+            3rd: iff out_azis=None, indicates if to save or discard the azimuths
+                 (see GeodIntermediateFlag.AZIS_*)
+            default - round npts, update del_s accordingly, discard azis
+        out_lons: array, :class:`numpy.ndarray`, optional
+            Longitude(s) of the intermediate point(s)
+            If None then buffers would be allocated internnaly
+        out_lats: array, :class:`numpy.ndarray`, optional
+            Latitudes(s) of the intermediate point(s)
+            If None then buffers would be allocated internnaly
+        out_azis: array, :class:`numpy.ndarray`, optional
+            az12(s) of the intermediate point(s)
+            If None then buffers would be allocated internnaly
+            unless requested otherwise by the flags
+
+        Returns
+        -------
+        GeodIntermediateReturn
+            number of points, distance and output arrays (GeodIntermediateReturn docs)
         """
-        super()._inv_intermediate(
-            out_lons=out_lons,
-            out_lats=out_lats,
-            out_azis=out_azis,
+        return super()._inv_or_fwd_intermediate(
             lon1=lon1,
             lat1=lat1,
-            lon2=lon2,
-            lat2=lat2,
+            lon2_or_azi1=lon2,
+            lat2_or_nan=lat2,
             npts=npts,
+            del_s=del_s,
             radians=radians,
             initial_idx=initial_idx,
             terminus_idx=terminus_idx,
+            flags=int(flags),
+            out_lons=out_lons,
+            out_lats=out_lats,
+            out_azis=out_azis,
+        )
+
+    def fwd_intermediate(
+        self,
+        lon1: float,
+        lat1: float,
+        azi1: float,
+        npts: int,
+        del_s: float,
+        initial_idx: int = 1,
+        terminus_idx: int = 1,
+        radians: bool = False,
+        flags: GeodIntermediateFlag = GeodIntermediateFlag.DEFAULT,
+        out_lons: Any = None,
+        out_lats: Any = None,
+        out_azis: Any = None,
+    ) -> GeodIntermediateReturn:
+        """
+        .. versionadded:: 3.1.0
+
+        Given a single initial point and azimuth, number of points (npts)
+        and delimiter distance between two successive points (del_s), returns
+        a list of longitude/latitude pairs describing npts equally
+        spaced intermediate points along the geodesic between the
+        initial and terminus points.
+
+        Example usage:
+
+        >>> from pyproj import Geod
+        >>> g = Geod(ellps='clrk66') # Use Clarke 1866 ellipsoid.
+        >>> # specify the lat/lons of Boston and Portland.
+        >>> boston_lat = 42.+(15./60.); boston_lon = -71.-(7./60.)
+        >>> portland_lat = 45.+(31./60.); portland_lon = -123.-(41./60.)
+        >>> az12,az21,dist = g.inv(boston_lon,boston_lat,portland_lon,portland_lat)
+        >>> # find ten equally spaced points between Boston and Portland.
+        >>> npts = 10
+        >>> del_s = dist/(npts+1)
+        >>> r = g.fwd_intermediate(boston_lon,boston_lat,az12,npts=npts,del_s=del_s)
+        >>> for lon,lat in zip(r.lons, r.lats): f'{lat:.3f} {lon:.3f}'
+        '43.528 -75.414'
+        '44.637 -79.883'
+        '45.565 -84.512'
+        '46.299 -89.279'
+        '46.830 -94.156'
+        '47.149 -99.112'
+        '47.251 -104.106'
+        '47.136 -109.100'
+        '46.805 -114.051'
+        '46.262 -118.924'
+        >>> # test with radians=True (inputs/outputs in radians, not degrees)
+        >>> import math
+        >>> dg2rad = math.radians(1.)
+        >>> rad2dg = math.degrees(1.)
+        >>> r = g.fwd_intermediate(
+        ...    dg2rad*boston_lon,
+        ...    dg2rad*boston_lat,
+        ...    dg2rad*az12,
+        ...    npts=npts,
+        ...    del_s=del_s,
+        ...    radians=True
+        ... )
+        >>> for lon,lat in zip(r.lons, r.lats): f'{rad2dg*lat:.3f} {rad2dg*lon:.3f}'
+        '43.528 -75.414'
+        '44.637 -79.883'
+        '45.565 -84.512'
+        '46.299 -89.279'
+        '46.830 -94.156'
+        '47.149 -99.112'
+        '47.251 -104.106'
+        '47.136 -109.100'
+        '46.805 -114.051'
+        '46.262 -118.924'
+
+        Parameters
+        ----------
+        lon1: float
+            Longitude of the initial point
+        lat1: float
+            Latitude of the initial point
+        azi1: float
+            Azimuth from the initial point towards the terminus point
+        npts: int
+            Number of points to be returned
+            (including initial and/or terminus points, if required)
+        del_s: float
+            delimiter distance between two successive points
+        radians: bool, optional
+            If True, the input data is assumed to be in radians.
+        initial_idx: int, optional
+            if initial_idx==0 then the initial point would be included in the output
+            (as the first point)
+        terminus_idx: int, optional
+            if terminus_idx==0 then the terminus point would be included in the output
+            (as the last point)
+        flags: GeodIntermediateFlag, optional
+            3rd: iff out_azis=None, indicates if to save or discard the azimuths
+                 (see GeodIntermediateFlag.AZIS_*)
+            default - discard azis
+        out_lons: array, :class:`numpy.ndarray`, optional
+            Longitude(s) of the intermediate point(s)
+            If None then buffers would be allocated internnaly
+        out_lats: array, :class:`numpy.ndarray`, optional
+            Latitudes(s) of the intermediate point(s)
+            If None then buffers would be allocated internnaly
+        out_azis: array, :class:`numpy.ndarray`, optional
+            az12(s) of the intermediate point(s)
+            If None then buffers would be allocated internnaly
+            unless requested otherwise by the flags
+
+        Returns
+        -------
+        GeodIntermediateReturn
+            number of points, distance and output arrays (GeodIntermediateReturn docs)
+        """
+        return super()._inv_or_fwd_intermediate(
+            lon1=lon1,
+            lat1=lat1,
+            lon2_or_azi1=azi1,
+            lat2_or_nan=math.nan,
+            npts=npts,
+            del_s=del_s,
+            radians=radians,
+            initial_idx=initial_idx,
+            terminus_idx=terminus_idx,
+            flags=int(flags),
+            out_lons=out_lons,
+            out_lats=out_lats,
+            out_azis=out_azis,
         )
 
     def line_length(self, lons: Any, lats: Any, radians: bool = False) -> float:

--- a/test/test_geod.py
+++ b/test/test_geod.py
@@ -7,6 +7,7 @@ import tempfile
 from contextlib import contextmanager
 from itertools import permutations
 
+import numpy as np
 import pytest
 from numpy.testing import assert_almost_equal
 
@@ -131,6 +132,48 @@ def test_geod_inverse_transform():
             assert_almost_equal(
                 (lat2pt, lon2pt, o_dist), (45.517, -123.683, 832838.542), decimal=3
             )
+
+        if include_initial and include_terminus:
+            lons, lats, azis12, azis21, dists = np.hstack(
+                (lonlats, res_az12_az21_dists)
+            ).transpose()
+
+    lons_a = np.empty(point_count)
+    lats_a = np.empty(point_count)
+    azis_a = np.empty(point_count)
+
+    gg.inv_intermediate(
+        out_lons=lons_a,
+        out_lats=lats_a,
+        out_azis=azis_a,
+        lon1=lon1pt,
+        lat1=lat1pt,
+        lon2=lon2pt,
+        lat2=lat2pt,
+        npts=point_count,
+        initial_idx=0,
+        terminus_idx=0,
+    )
+
+    assert_almost_equal(lons_a, lons)
+    assert_almost_equal(lats_a, lats)
+    assert_almost_equal(azis_a[:-1], azis12[1:])
+
+    gg.inv_intermediate(
+        out_lons=lons_a,
+        out_lats=lats_a,
+        out_azis=None,
+        lon1=lon1pt,
+        lat1=lat1pt,
+        lon2=lon2pt,
+        lat2=lat2pt,
+        npts=point_count,
+        initial_idx=0,
+        terminus_idx=0,
+    )
+
+    assert_almost_equal(lons_a, lons)
+    assert_almost_equal(lats_a, lats)
 
 
 def test_geod_cities():


### PR DESCRIPTION
pyproj/geod.py - add a parameter `return_points` to Geod.npts() to determinate the return type; improve return type hint
pyproj/geod.py - add a parameters `initial_idx`, `terminus_idx` to Geod.npts()
pyproj/[geod.py, _geod.pyi, _geod.pyx] - add `inv_intermediate_by_npts` functions that uses given buffers `out_lons`, `out_lats` (and `out_azis`) buffers instead of creating new buffers
pyproj/_geod.pxd - add interface for `geod_lineinit`
pyproj/[geod.py, _geod.pyi, _geod.pyx] - add `inv_intermediate_by_del`, `fwd_intermediate_by_npts`, `fwd_intermediate_by_del` functions, similar to `inv_npts` but using forward calculation
test/test_geod.py - add tests for new functions

## Related PR

https://github.com/pyproj4/pyproj/pull/825/