### PR TITLE
changing constructor-methods from staticmethods to classmethods

### DIFF
--- a/pyproj/crs/crs.py
+++ b/pyproj/crs/crs.py
@@ -1489,12 +1489,13 @@ class _CleanlyInheritableCRS(CRS):
 
 # remove from_* factory methods in _CleanlyInheritableCRS. They can't be deleted, as that would delete them from the
 # parent CRS. Best we can do is override them with a property which raises AttributeError.
-for item in CRS.__dict__:
+for item in CRS.__dict__.keys():
+    if item.startswith("from_"):
 
-    def _override(self):
-        raise AttributeError(f"method '{item}' is not accessible from this class")
+        def _override(self, item=item):
+            raise AttributeError(f"method '{item}' is not accessible from this class")
 
-    setattr(_CleanlyInheritableCRS, item, property(_override))
+        setattr(_CleanlyInheritableCRS, item, _override)
 
 
 class GeographicCRS(_CleanlyInheritableCRS):

--- a/pyproj/crs/crs.py
+++ b/pyproj/crs/crs.py
@@ -321,8 +321,8 @@ class CRS:
             self._local.crs = _CRS(self.srs)
         return self._local.crs
 
-    @staticmethod
-    def from_authority(auth_name: str, code: Union[str, int]) -> "CRS":
+    @classmethod
+    def from_authority(cls, auth_name: str, code: Union[str, int]) -> "CRS":
         """
         .. versionadded:: 2.2.0
 
@@ -339,10 +339,10 @@ class CRS:
         -------
         CRS
         """
-        return CRS(_prepare_from_authority(auth_name, code))
+        return cls(_prepare_from_authority(auth_name, code))
 
-    @staticmethod
-    def from_epsg(code: Union[str, int]) -> "CRS":
+    @classmethod
+    def from_epsg(cls, code: Union[str, int]) -> "CRS":
         """Make a CRS from an EPSG code
 
         Parameters
@@ -354,10 +354,10 @@ class CRS:
         -------
         CRS
         """
-        return CRS(_prepare_from_epsg(code))
+        return cls(_prepare_from_epsg(code))
 
-    @staticmethod
-    def from_proj4(in_proj_string: str) -> "CRS":
+    @classmethod
+    def from_proj4(cls, in_proj_string: str) -> "CRS":
         """
         .. versionadded:: 2.2.0
 
@@ -374,10 +374,10 @@ class CRS:
         """
         if not is_proj(in_proj_string):
             raise CRSError(f"Invalid PROJ string: {in_proj_string}")
-        return CRS(_prepare_from_string(in_proj_string))
+        return cls(_prepare_from_string(in_proj_string))
 
-    @staticmethod
-    def from_wkt(in_wkt_string: str) -> "CRS":
+    @classmethod
+    def from_wkt(cls, in_wkt_string: str) -> "CRS":
         """
         .. versionadded:: 2.2.0
 
@@ -394,10 +394,10 @@ class CRS:
         """
         if not is_wkt(in_wkt_string):
             raise CRSError(f"Invalid WKT string: {in_wkt_string}")
-        return CRS(_prepare_from_string(in_wkt_string))
+        return cls(_prepare_from_string(in_wkt_string))
 
-    @staticmethod
-    def from_string(in_crs_string: str) -> "CRS":
+    @classmethod
+    def from_string(cls, in_crs_string: str) -> "CRS":
         """
         Make a CRS from:
 
@@ -416,7 +416,7 @@ class CRS:
         -------
         CRS
         """
-        return CRS(_prepare_from_string(in_crs_string))
+        return cls(_prepare_from_string(in_crs_string))
 
     def to_string(self) -> str:
         """
@@ -437,8 +437,8 @@ class CRS:
             return ":".join(auth_info)
         return self.srs
 
-    @staticmethod
-    def from_user_input(value: Any, **kwargs) -> "CRS":
+    @classmethod
+    def from_user_input(cls, value: Any, **kwargs) -> "CRS":
         """
         Initialize a CRS class instance with:
           - PROJ string
@@ -463,7 +463,7 @@ class CRS:
         """
         if isinstance(value, CRS):
             return value
-        return CRS(value, **kwargs)
+        return cls(value, **kwargs)
 
     def get_geod(self) -> Optional[Geod]:
         """
@@ -480,8 +480,8 @@ class CRS:
             b=self.ellipsoid.semi_minor_metre,
         )
 
-    @staticmethod
-    def from_dict(proj_dict: dict) -> "CRS":
+    @classmethod
+    def from_dict(cls, proj_dict: dict) -> "CRS":
         """
         .. versionadded:: 2.2.0
 
@@ -496,10 +496,10 @@ class CRS:
         -------
         CRS
         """
-        return CRS(_prepare_from_dict(proj_dict))
+        return cls(_prepare_from_dict(proj_dict))
 
-    @staticmethod
-    def from_json(crs_json: str) -> "CRS":
+    @classmethod
+    def from_json(cls, crs_json: str) -> "CRS":
         """
         .. versionadded:: 2.4.0
 
@@ -514,10 +514,10 @@ class CRS:
         -------
         CRS
         """
-        return CRS.from_json_dict(_load_proj_json(crs_json))
+        return cls.from_json_dict(_load_proj_json(crs_json))
 
-    @staticmethod
-    def from_json_dict(crs_dict: dict) -> "CRS":
+    @classmethod
+    def from_json_dict(cls, crs_dict: dict) -> "CRS":
         """
         .. versionadded:: 2.4.0
 
@@ -532,7 +532,7 @@ class CRS:
         -------
         CRS
         """
-        return CRS(json.dumps(crs_dict))
+        return cls(json.dumps(crs_dict))
 
     def to_dict(self) -> dict:
         """

--- a/pyproj/crs/crs.py
+++ b/pyproj/crs/crs.py
@@ -1481,7 +1481,23 @@ class CRS:
         )
 
 
-class GeographicCRS(CRS):
+class _CleanlyInheritableCRS(CRS):
+    """
+    This class exists to remove certain attributes from inheritance which do not make sense for certain derived classes.
+    """
+
+
+# remove from_* factory methods in _CleanlyInheritableCRS. They can't be deleted, as that would delete them from the
+# parent CRS. Best we can do is override them with a property which raises AttributeError.
+for item in CRS.__dict__:
+
+    def _override(self):
+        raise AttributeError(f"method '{item}' is not accessible from this class")
+
+    setattr(_CleanlyInheritableCRS, item, property(_override))
+
+
+class GeographicCRS(_CleanlyInheritableCRS):
     """
     .. versionadded:: 2.5.0
 
@@ -1519,7 +1535,7 @@ class GeographicCRS(CRS):
         super().__init__(geographic_crs_json)
 
 
-class DerivedGeographicCRS(CRS):
+class DerivedGeographicCRS(_CleanlyInheritableCRS):
     """
     .. versionadded:: 2.5.0
 
@@ -1564,7 +1580,7 @@ class DerivedGeographicCRS(CRS):
         super().__init__(derived_geographic_crs_json)
 
 
-class ProjectedCRS(CRS):
+class ProjectedCRS(_CleanlyInheritableCRS):
     """
     .. versionadded:: 2.5.0
 
@@ -1611,7 +1627,7 @@ class ProjectedCRS(CRS):
         super().__init__(proj_crs_json)
 
 
-class VerticalCRS(CRS):
+class VerticalCRS(_CleanlyInheritableCRS):
     """
     .. versionadded:: 2.5.0
 
@@ -1657,7 +1673,7 @@ class VerticalCRS(CRS):
         super().__init__(vert_crs_json)
 
 
-class CompoundCRS(CRS):
+class CompoundCRS(_CleanlyInheritableCRS):
     """
     .. versionadded:: 2.5.0
 
@@ -1687,7 +1703,7 @@ class CompoundCRS(CRS):
         super().__init__(compound_crs_json)
 
 
-class BoundCRS(CRS):
+class BoundCRS(_CleanlyInheritableCRS):
     """
     .. versionadded:: 2.5.0
 

--- a/pyproj/transformer.py
+++ b/pyproj/transformer.py
@@ -417,8 +417,9 @@ class Transformer:
         """
         return self._transformer.is_network_enabled
 
-    @staticmethod
+    @classmethod
     def from_proj(
+        cls,
         proj_from: Any,
         proj_to: Any,
         skip_equivalent: bool = False,
@@ -461,7 +462,7 @@ class Transformer:
         if not isinstance(proj_to, Proj):
             proj_to = Proj(proj_to)
 
-        return Transformer.from_crs(
+        return cls.from_crs(
             proj_from.crs,
             proj_to.crs,
             skip_equivalent=skip_equivalent,
@@ -469,8 +470,9 @@ class Transformer:
             area_of_interest=area_of_interest,
         )
 
-    @staticmethod
+    @classmethod
     def from_crs(
+        cls,
         crs_from: Any,
         crs_to: Any,
         skip_equivalent: bool = False,
@@ -533,7 +535,7 @@ class Transformer:
                 stacklevel=2,
             )
 
-        return Transformer(
+        return cls(
             TransformerFromCRS(
                 CRS.from_user_input(crs_from).srs,
                 CRS.from_user_input(crs_to).srs,
@@ -545,8 +547,8 @@ class Transformer:
             )
         )
 
-    @staticmethod
-    def from_pipeline(proj_pipeline: str) -> "Transformer":
+    @classmethod
+    def from_pipeline(cls, proj_pipeline: str) -> "Transformer":
         """Make a Transformer from a PROJ pipeline string.
 
         https://proj.org/operations/pipeline.html
@@ -576,7 +578,7 @@ class Transformer:
         Transformer
 
         """
-        return Transformer(TransformerFromPipeline(proj_pipeline))
+        return cls(TransformerFromPipeline(proj_pipeline))
 
     def transform(
         self,

--- a/test/crs/test_crs.py
+++ b/test/crs/test_crs.py
@@ -1483,3 +1483,10 @@ def test_subclassing():
             return 7
 
     assert myCRS.from_epsg(4326).foo_method() == 7
+
+
+def test_from_methods():
+    with pytest.raises(AttributeError):
+        pyproj.crs.VerticalCRS.from_epsg
+    with pytest.raises(AttributeError):
+        pyproj.crs.VerticalCRS.from_proj4

--- a/test/crs/test_crs.py
+++ b/test/crs/test_crs.py
@@ -1475,3 +1475,10 @@ def test_to_3d(crs_input):
 def test_to_3d__name():
     crs_3d = CRS("EPSG:2056").to_3d(name="TEST")
     assert crs_3d.name == "TEST"
+
+def test_subclassing():
+    class myCRS(CRS):
+        def foo_method(self):
+            return 7
+
+    assert myCRS.from_epsg(4326).foo_method() == 7

--- a/test/crs/test_crs.py
+++ b/test/crs/test_crs.py
@@ -1476,6 +1476,7 @@ def test_to_3d__name():
     crs_3d = CRS("EPSG:2056").to_3d(name="TEST")
     assert crs_3d.name == "TEST"
 
+
 def test_subclassing():
     class myCRS(CRS):
         def foo_method(self):


### PR DESCRIPTION
changes use of staticmethods to classmethods in constructor-methods in Transformer and CRS. I left from_cf in CRS, as there is some logic in there on whether to return a CRS, a GeographicCRS, a DerivedGeographicCRS, or a CompoundCRS. It may require some rethinking on how handle that properly with classmethods. 

 - [ x] Closes #847
 - [ x] Tests added
