### PR TITLE
DEP: Add types-certifi to dev requirements

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -17,7 +17,7 @@ jobs:
       - uses: pre-commit/action@v2.0.0
       - name: Install mypy
         run: |
-          python -m pip install mypy
+          python -m pip install mypy types-certifi
       - name: mypy
         run: |
           mypy pyproj

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
 cython>=0.28.4
 mypy
+types-certifi
 pre-commit


### PR DESCRIPTION
From: https://github.com/pyproj4/pyproj/runs/2923083567
```
pyproj/network.py:8: error: Library stubs not installed for "certifi" (or incompatible with Python 3.9)
pyproj/network.py:8: note: Hint: "python3 -m pip install types-certifi"
pyproj/network.py:8: note: (or run "mypy --install-types" to install all missing stub packages)
pyproj/network.py:8: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
pyproj/network.py:57: error: Argument 1 to "_set_ca_bundle_path" has incompatible type "Union[Path, str, bool, None]"; expected "str"
```