### PR TITLE
BUG: Fix spelling for AzimuthalEquidistantConversion and LambertAzimuthalEqualAreaConversion

### DIFF
--- a/docs/api/crs/coordinate_operation.rst
+++ b/docs/api/crs/coordinate_operation.rst
@@ -32,10 +32,10 @@ AlbersEqualAreaConversion
     :special-members: __new__
 
 
-AzumuthalEquidistantConversion
+AzimuthalEquidistantConversion
 -------------------------------
 
-.. autoclass:: pyproj.crs.coordinate_operation.AzumuthalEquidistantConversion
+.. autoclass:: pyproj.crs.coordinate_operation.AzimuthalEquidistantConversion
     :members:
     :show-inheritance:
     :special-members: __new__
@@ -58,10 +58,10 @@ GeostationarySatelliteConversion
     :special-members: __new__
 
 
-LambertAzumuthalEqualAreaConversion
+LambertAzimuthalEqualAreaConversion
 -----------------------------------
 
-.. autoclass:: pyproj.crs.coordinate_operation.LambertAzumuthalEqualAreaConversion
+.. autoclass:: pyproj.crs.coordinate_operation.LambertAzimuthalEqualAreaConversion
     :members:
     :show-inheritance:
     :special-members: __new__

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -7,6 +7,9 @@ Latest
 - REF: Handle deprecation of proj_context_set_autoclose_database (issue #866)
 - DOC: Improve FAQ text about CRS formats (issue #789)
 - BUG: Add PyPy cython array implementation (issue #854)
+- BUG: Fix spelling for
+  :class:`pyproj.crs.coordinate_operation.AzimuthalEquidistantConversion`
+  and :class:`pyproj.crs.coordinate_operation.LambertAzimuthalEqualAreaConversion` (issue #882)
 
 3.1.0
 -----

--- a/pyproj/crs/_cf1x8.py
+++ b/pyproj/crs/_cf1x8.py
@@ -10,10 +10,10 @@ import warnings
 from pyproj._crs import Datum, Ellipsoid, PrimeMeridian
 from pyproj.crs.coordinate_operation import (
     AlbersEqualAreaConversion,
-    AzumuthalEquidistantConversion,
+    AzimuthalEquidistantConversion,
     GeostationarySatelliteConversion,
     HotineObliqueMercatorBConversion,
-    LambertAzumuthalEqualAreaConversion,
+    LambertAzimuthalEqualAreaConversion,
     LambertConformalConic1SPConversion,
     LambertConformalConic2SPConversion,
     LambertCylindricalEqualAreaConversion,
@@ -117,7 +117,7 @@ def _azimuthal_equidistant(cf_params):
     """
     http://cfconventions.org/cf-conventions/cf-conventions.html#azimuthal-equidistant
     """
-    return AzumuthalEquidistantConversion(
+    return AzimuthalEquidistantConversion(
         latitude_natural_origin=cf_params.get("latitude_of_projection_origin", 0.0),
         longitude_natural_origin=cf_params.get("longitude_of_projection_origin", 0.0),
         false_easting=cf_params.get("false_easting", 0.0),
@@ -147,7 +147,7 @@ def _lambert_azimuthal_equal_area(cf_params):
     """
     http://cfconventions.org/cf-conventions/cf-conventions.html#lambert-azimuthal-equal-area
     """
-    return LambertAzumuthalEqualAreaConversion(
+    return LambertAzimuthalEqualAreaConversion(
         latitude_natural_origin=cf_params.get("latitude_of_projection_origin", 0.0),
         longitude_natural_origin=cf_params.get("longitude_of_projection_origin", 0.0),
         false_easting=cf_params.get("false_easting", 0.0),

--- a/pyproj/crs/coordinate_operation.py
+++ b/pyproj/crs/coordinate_operation.py
@@ -103,9 +103,10 @@ class AlbersEqualAreaConversion(CoordinateOperation):
         return cls.from_json_dict(aea_json)
 
 
-class AzumuthalEquidistantConversion(CoordinateOperation):
+class AzimuthalEquidistantConversion(CoordinateOperation):
     """
-    .. versionadded:: 2.5.0
+    .. versionadded:: 2.5.0 AzumuthalEquidistantConversion
+    .. versionadded:: 3.2.0 AzimuthalEquidistantConversion
 
     Class for constructing the Modified Azimuthal Equidistant conversion.
 
@@ -168,6 +169,36 @@ class AzumuthalEquidistantConversion(CoordinateOperation):
             ],
         }
         return cls.from_json_dict(aeqd_json)
+
+
+class AzumuthalEquidistantConversion(AzimuthalEquidistantConversion):
+    """
+    For backwards compatibility.
+
+    .. versionadded:: 2.5.0
+    .. deprecated:: 3.2.0
+    """
+
+    def __new__(
+        cls,
+        latitude_natural_origin: float = 0.0,
+        longitude_natural_origin: float = 0.0,
+        false_easting: float = 0.0,
+        false_northing: float = 0.0,
+    ):
+        warnings.warn(
+            "AzumuthalEquidistantConversion is deprecated. "
+            "Please use AzimuthalEquidistantConversion.",
+            FutureWarning,
+            stacklevel=2,
+        )
+        return AzimuthalEquidistantConversion.__new__(
+            AzimuthalEquidistantConversion,
+            latitude_natural_origin=latitude_natural_origin,
+            longitude_natural_origin=longitude_natural_origin,
+            false_easting=false_easting,
+            false_northing=false_northing,
+        )
 
 
 class GeostationarySatelliteConversion(CoordinateOperation):
@@ -257,9 +288,10 @@ class GeostationarySatelliteConversion(CoordinateOperation):
         return cls.from_json_dict(geos_json)
 
 
-class LambertAzumuthalEqualAreaConversion(CoordinateOperation):
+class LambertAzimuthalEqualAreaConversion(CoordinateOperation):
     """
-    .. versionadded:: 2.5.0
+    .. versionadded:: 2.5.0 LambertAzumuthalEqualAreaConversion
+    .. versionadded:: 3.2.0 LambertAzimuthalEqualAreaConversion
 
     Class for constructing the Lambert Azimuthal Equal Area conversion.
 
@@ -322,6 +354,36 @@ class LambertAzumuthalEqualAreaConversion(CoordinateOperation):
             ],
         }
         return cls.from_json_dict(laea_json)
+
+
+class LambertAzumuthalEqualAreaConversion(LambertAzimuthalEqualAreaConversion):
+    """
+    For backwards compatibility.
+
+    .. versionadded:: 2.5.0
+    .. deprecated:: 3.2.0
+    """
+
+    def __new__(
+        cls,
+        latitude_natural_origin: float = 0.0,
+        longitude_natural_origin: float = 0.0,
+        false_easting: float = 0.0,
+        false_northing: float = 0.0,
+    ):
+        warnings.warn(
+            "LambertAzumuthalEqualAreaConversion is deprecated. "
+            "Please use LambertAzimuthalEqualAreaConversion.",
+            FutureWarning,
+            stacklevel=2,
+        )
+        return LambertAzimuthalEqualAreaConversion.__new__(
+            LambertAzimuthalEqualAreaConversion,
+            latitude_natural_origin=latitude_natural_origin,
+            longitude_natural_origin=longitude_natural_origin,
+            false_easting=false_easting,
+            false_northing=false_northing,
+        )
 
 
 class LambertConformalConic2SPConversion(CoordinateOperation):

--- a/test/crs/test_crs_cf.py
+++ b/test/crs/test_crs_cf.py
@@ -8,7 +8,7 @@ from pyproj import CRS
 from pyproj.crs import ProjectedCRS
 from pyproj.crs._cf1x8 import _try_list_if_string
 from pyproj.crs.coordinate_operation import (
-    LambertAzumuthalEqualAreaConversion,
+    LambertAzimuthalEqualAreaConversion,
     LambertCylindricalEqualAreaConversion,
     MercatorAConversion,
     OrthographicConversion,
@@ -1129,7 +1129,7 @@ def test_azimuthal_equidistant():
 
 
 def test_lambert_azimuthal_equal_area():
-    crs = ProjectedCRS(conversion=LambertAzumuthalEqualAreaConversion(1, 2, 3, 4))
+    crs = ProjectedCRS(conversion=LambertAzimuthalEqualAreaConversion(1, 2, 3, 4))
     expected_cf = {
         "semi_major_axis": 6378137.0,
         "semi_minor_axis": crs.ellipsoid.semi_minor_metre,

--- a/test/crs/test_crs_coordinate_operation.py
+++ b/test/crs/test_crs_coordinate_operation.py
@@ -4,10 +4,12 @@ from numpy.testing import assert_almost_equal
 from pyproj.crs import GeographicCRS
 from pyproj.crs.coordinate_operation import (
     AlbersEqualAreaConversion,
+    AzimuthalEquidistantConversion,
     AzumuthalEquidistantConversion,
     EquidistantCylindricalConversion,
     GeostationarySatelliteConversion,
     HotineObliqueMercatorBConversion,
+    LambertAzimuthalEqualAreaConversion,
     LambertAzumuthalEqualAreaConversion,
     LambertConformalConic1SPConversion,
     LambertConformalConic2SPConversion,
@@ -74,8 +76,21 @@ def test_albers_equal_area_operation():
     }
 
 
+def test_azumuthal_equidistant_operation__defaults():
+    with pytest.warns(FutureWarning, match="deprecated"):
+        aeop = AzumuthalEquidistantConversion()
+    assert aeop.name == "unknown"
+    assert aeop.method_name == "Modified Azimuthal Equidistant"
+    assert _to_dict(aeop) == {
+        "Latitude of natural origin": 0.0,
+        "Longitude of natural origin": 0.0,
+        "False easting": 0.0,
+        "False northing": 0.0,
+    }
+
+
 def test_azimuthal_equidistant_operation__defaults():
-    aeop = AzumuthalEquidistantConversion()
+    aeop = AzimuthalEquidistantConversion()
     assert aeop.name == "unknown"
     assert aeop.method_name == "Modified Azimuthal Equidistant"
     assert _to_dict(aeop) == {
@@ -87,7 +102,7 @@ def test_azimuthal_equidistant_operation__defaults():
 
 
 def test_azimuthal_equidistant_operation():
-    aeop = AzumuthalEquidistantConversion(
+    aeop = AzimuthalEquidistantConversion(
         latitude_natural_origin=1,
         longitude_natural_origin=2,
         false_easting=3,
@@ -142,8 +157,21 @@ def test_geostationary_operation__invalid_sweep():
         GeostationarySatelliteConversion(sweep_angle_axis="P", satellite_height=10)
 
 
+def test_lambert_azumuthal_equal_area_operation__defaults():
+    with pytest.warns(FutureWarning, match="deprecated"):
+        aeop = LambertAzumuthalEqualAreaConversion()
+    assert aeop.name == "unknown"
+    assert aeop.method_name == "Lambert Azimuthal Equal Area"
+    assert _to_dict(aeop) == {
+        "Latitude of natural origin": 0.0,
+        "Longitude of natural origin": 0.0,
+        "False easting": 0.0,
+        "False northing": 0.0,
+    }
+
+
 def test_lambert_azimuthal_equal_area_operation__defaults():
-    aeop = LambertAzumuthalEqualAreaConversion()
+    aeop = LambertAzimuthalEqualAreaConversion()
     assert aeop.name == "unknown"
     assert aeop.method_name == "Lambert Azimuthal Equal Area"
     assert _to_dict(aeop) == {
@@ -155,7 +183,7 @@ def test_lambert_azimuthal_equal_area_operation__defaults():
 
 
 def test_lambert_azimuthal_equal_area_operation():
-    aeop = LambertAzumuthalEqualAreaConversion(
+    aeop = LambertAzimuthalEqualAreaConversion(
         latitude_natural_origin=1,
         longitude_natural_origin=2,
         false_easting=3,


### PR DESCRIPTION

<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Closes #882
 - [x] Tests added
 - [x] Fully documented, including `history.rst` for all changes and `api/*.rst` for new API
