### PR TITLE
Revert "ENH: Allow cimport (#870)"

### DIFF
--- a/docs/history.rst
+++ b/docs/history.rst
@@ -3,7 +3,6 @@ Change Log
 
 Latest
 ------
-- ENH: Allow cimport (pull #870)
 - REF: Handle deprecation of proj_context_set_autoclose_database (issue #866)
 - DOC: Improve FAQ text about CRS formats (issue #789)
 - BUG: Add PyPy cython array implementation (issue #854)

--- a/pyproj/_geod.pxd
+++ b/pyproj/_geod.pxd
@@ -1,7 +1,3 @@
-# WARNING: cartopy uses pyproj to import PROJ geodesic routines.
-# Check what cartopy uses before removing any definitions.
-
-
 cdef extern from "geodesic.h":
     struct geod_geodesic:
         pass
@@ -69,18 +65,6 @@ cdef extern from "geodesic.h":
         GEODESIC_VERSION_MAJOR
         GEODESIC_VERSION_MINOR
         GEODESIC_VERSION_PATCH
-
-    # FOR CARTOPY ONLY
-    cdef int GEOD_ARCMODE
-    cdef int GEOD_LATITUDE
-    cdef int GEOD_LONGITUDE
-
-    double geod_geninverse(geod_geodesic*, double, double, double, double,
-                           double*, double*, double*, double*, double*,
-                           double*, double*) nogil
-    void geod_genposition(geod_geodesicline*, int, double, double*,
-                          double*, double*, double*, double*, double*,
-                          double*, double*) nogil
 
 
 cdef class Geod:

--- a/setup.py
+++ b/setup.py
@@ -195,7 +195,7 @@ def get_package_data() -> Dict[str, List[str]]:
     This function retrieves the package data
     """
     # setup package data
-    package_data = {"pyproj": ["*.pyi", "py.typed", "*.pyx", "*.pxd"]}
+    package_data = {"pyproj": ["*.pyi", "py.typed"]}
     if os.environ.get("PROJ_WHEEL") is not None and INTERNAL_PROJ_DIR.exists():
         package_data["pyproj"].append(
             str(BASE_INTERNAL_PROJ_DIR / "share" / "proj" / "*")


### PR DESCRIPTION
This reverts commit 6ef2d4fe971151bc48878319193e71fab86b3d36.

Based on what I have seen so far, this doesn't really provide much benefit due to the connection to the external PROJ. It also requires adding pyproj as a pre-build requirement. So, I think it would be better to wait on this until the benefits are more clear and more investigation has been completed.
