### PR TITLE
REF: Modify custom CRS classes to be functions that return CRS

### DIFF
--- a/docs/api/crs/crs.rst
+++ b/docs/api/crs/crs.rst
@@ -15,54 +15,36 @@ CRS
 GeographicCRS
 ------------------------
 
-.. autoclass:: pyproj.crs.GeographicCRS
-    :members:
-    :show-inheritance:
-    :special-members: __init__
+.. autofunction:: pyproj.crs.GeographicCRS
 
 
 DerivedGeographicCRS
 ------------------------
 
-.. autoclass:: pyproj.crs.DerivedGeographicCRS
-    :members:
-    :show-inheritance:
-    :special-members: __init__
+.. autofunction:: pyproj.crs.DerivedGeographicCRS
 
 
 ProjectedCRS
 -----------------------
 
-.. autoclass:: pyproj.crs.ProjectedCRS
-    :members:
-    :show-inheritance:
-    :special-members: __init__
+.. autofunction:: pyproj.crs.ProjectedCRS
 
 
 VerticalCRS
 -----------------------
 
-.. autoclass:: pyproj.crs.VerticalCRS
-    :members:
-    :show-inheritance:
-    :special-members: __init__
+.. autofunction:: pyproj.crs.VerticalCRS
 
 
 BoundCRS
 -----------------------
 
-.. autoclass:: pyproj.crs.BoundCRS
-    :members:
-    :show-inheritance:
-    :special-members: __init__
+.. autofunction:: pyproj.crs.BoundCRS
 
 CompoundCRS
 -----------------------
 
-.. autoclass:: pyproj.crs.CompoundCRS
-    :members:
-    :show-inheritance:
-    :special-members: __init__
+.. autofunction:: pyproj.crs.CompoundCRS
 
 
 is_wkt

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -4,6 +4,7 @@ Change Log
 Latest
 ------
 - REF: Handle deprecation of proj_context_set_autoclose_database (issue #866)
+- REF: Modify custom CRS classes to be functions that return CRS (issue #897)
 - DOC: Improve FAQ text about CRS formats (issue #789)
 - BUG: Add PyPy cython array implementation (issue #854)
 - BUG: Fix spelling for

--- a/pyproj/crs/crs.py
+++ b/pyproj/crs/crs.py
@@ -1479,238 +1479,206 @@ class CRS:
         )
 
 
-class GeographicCRS(CRS):
+def GeographicCRS(
+    name: str = "undefined",
+    datum: Any = "urn:ogc:def:datum:EPSG::6326",
+    ellipsoidal_cs: Any = None,
+) -> CRS:
     """
     .. versionadded:: 2.5.0
 
-    This class is for building a Geographic CRS
+    Builds a Geographic CRS
+
+    Parameters
+    ----------
+    name: str, default="undefined"
+        Name of the CRS.
+    datum: Any, default="urn:ogc:def:datum:EPSG::6326"
+        Anything accepted by :meth:`pyproj.crs.Datum.from_user_input` or
+        a :class:`pyproj.crs.datum.CustomDatum`.
+    ellipsoidal_cs: Any, optional
+        Input to create an Ellipsoidal Coordinate System.
+        Anything accepted by :meth:`pyproj.crs.CoordinateSystem.from_user_input`
+        or an Ellipsoidal Coordinate System created from :ref:`coordinate_system`.
     """
-
-    def __init__(
-        self,
-        name: str = "undefined",
-        datum: Any = "urn:ogc:def:datum:EPSG::6326",
-        ellipsoidal_cs: Any = None,
-    ) -> None:
-        """
-        Parameters
-        ----------
-        name: str, default="undefined"
-            Name of the CRS.
-        datum: Any, default="urn:ogc:def:datum:EPSG::6326"
-            Anything accepted by :meth:`pyproj.crs.Datum.from_user_input` or
-            a :class:`pyproj.crs.datum.CustomDatum`.
-        ellipsoidal_cs: Any, optional
-            Input to create an Ellipsoidal Coordinate System.
-            Anything accepted by :meth:`pyproj.crs.CoordinateSystem.from_user_input`
-            or an Ellipsoidal Coordinate System created from :ref:`coordinate_system`.
-        """
-        geographic_crs_json = {
-            "$schema": "https://proj.org/schemas/v0.2/projjson.schema.json",
-            "type": "GeographicCRS",
-            "name": name,
-            "datum": Datum.from_user_input(datum).to_json_dict(),
-            "coordinate_system": CoordinateSystem.from_user_input(
-                ellipsoidal_cs or Ellipsoidal2DCS()
-            ).to_json_dict(),
-        }
-        super().__init__(geographic_crs_json)
+    geographic_crs_json = {
+        "$schema": "https://proj.org/schemas/v0.2/projjson.schema.json",
+        "type": "GeographicCRS",
+        "name": name,
+        "datum": Datum.from_user_input(datum).to_json_dict(),
+        "coordinate_system": CoordinateSystem.from_user_input(
+            ellipsoidal_cs or Ellipsoidal2DCS()
+        ).to_json_dict(),
+    }
+    return CRS(geographic_crs_json)
 
 
-class DerivedGeographicCRS(CRS):
+def DerivedGeographicCRS(
+    base_crs: Any,
+    conversion: Any,
+    ellipsoidal_cs: Any = None,
+    name: str = "undefined",
+) -> CRS:
     """
     .. versionadded:: 2.5.0
 
-    This class is for building a Derived Geographic CRS
+    Builds a Derived Geographic CRS
+
+    Parameters
+    ----------
+    base_crs: Any
+        Input to create the Geodetic CRS, a :func:`GeographicCRS` or
+        anything accepted by :meth:`pyproj.crs.CRS.from_user_input`.
+    conversion: Any
+        Anything accepted by :meth:`pyproj.crs.CoordinateSystem.from_user_input`
+        or a conversion from :ref:`coordinate_operation`.
+    ellipsoidal_cs: Any, optional
+        Input to create an Ellipsoidal Coordinate System.
+        Anything accepted by :meth:`pyproj.crs.CoordinateSystem.from_user_input`
+        or an Ellipsoidal Coordinate System created from :ref:`coordinate_system`.
+    name: str, default="undefined"
+        Name of the CRS.
     """
-
-    def __init__(
-        self,
-        base_crs: Any,
-        conversion: Any,
-        ellipsoidal_cs: Any = None,
-        name: str = "undefined",
-    ) -> None:
-        """
-        Parameters
-        ----------
-        base_crs: Any
-            Input to create the Geodetic CRS, a :class:`GeographicCRS` or
-            anything accepted by :meth:`pyproj.crs.CRS.from_user_input`.
-        conversion: Any
-            Anything accepted by :meth:`pyproj.crs.CoordinateSystem.from_user_input`
-            or a conversion from :ref:`coordinate_operation`.
-        ellipsoidal_cs: Any, optional
-            Input to create an Ellipsoidal Coordinate System.
-            Anything accepted by :meth:`pyproj.crs.CoordinateSystem.from_user_input`
-            or an Ellipsoidal Coordinate System created from :ref:`coordinate_system`.
-        name: str, default="undefined"
-            Name of the CRS.
-        """
-        derived_geographic_crs_json = {
-            "$schema": "https://proj.org/schemas/v0.2/projjson.schema.json",
-            "type": "DerivedGeographicCRS",
-            "name": name,
-            "base_crs": CRS.from_user_input(base_crs).to_json_dict(),
-            "conversion": CoordinateOperation.from_user_input(
-                conversion
-            ).to_json_dict(),
-            "coordinate_system": CoordinateSystem.from_user_input(
-                ellipsoidal_cs or Ellipsoidal2DCS()
-            ).to_json_dict(),
-        }
-        super().__init__(derived_geographic_crs_json)
+    derived_geographic_crs_json = {
+        "$schema": "https://proj.org/schemas/v0.2/projjson.schema.json",
+        "type": "DerivedGeographicCRS",
+        "name": name,
+        "base_crs": CRS.from_user_input(base_crs).to_json_dict(),
+        "conversion": CoordinateOperation.from_user_input(conversion).to_json_dict(),
+        "coordinate_system": CoordinateSystem.from_user_input(
+            ellipsoidal_cs or Ellipsoidal2DCS()
+        ).to_json_dict(),
+    }
+    return CRS(derived_geographic_crs_json)
 
 
-class ProjectedCRS(CRS):
+def ProjectedCRS(
+    conversion: Any,
+    name: str = "undefined",
+    cartesian_cs: Any = None,
+    geodetic_crs: Any = None,
+) -> CRS:
     """
     .. versionadded:: 2.5.0
 
-    This class is for building a Projected CRS.
+    Builds a Projected CRS.
+
+    Parameters
+    ----------
+    conversion: Any
+        Anything accepted by :meth:`pyproj.crs.CoordinateSystem.from_user_input`
+        or a conversion from :ref:`coordinate_operation`.
+    name: str, optional
+        The name of the Projected CRS. Default is undefined.
+    cartesian_cs: Any, optional
+        Input to create a Cartesian Coordinate System.
+        Anything accepted by :meth:`pyproj.crs.CoordinateSystem.from_user_input`
+        or :class:`pyproj.crs.coordinate_system.Cartesian2DCS`.
+    geodetic_crs: Any, optional
+        Input to create the Geodetic CRS, a :func:`GeographicCRS` or
+        anything accepted by :meth:`pyproj.crs.CRS.from_user_input`.
     """
-
-    def __init__(
-        self,
-        conversion: Any,
-        name: str = "undefined",
-        cartesian_cs: Any = None,
-        geodetic_crs: Any = None,
-    ) -> None:
-        """
-        Parameters
-        ----------
-        conversion: Any
-            Anything accepted by :meth:`pyproj.crs.CoordinateSystem.from_user_input`
-            or a conversion from :ref:`coordinate_operation`.
-        name: str, optional
-            The name of the Projected CRS. Default is undefined.
-        cartesian_cs: Any, optional
-            Input to create a Cartesian Coordinate System.
-            Anything accepted by :meth:`pyproj.crs.CoordinateSystem.from_user_input`
-            or :class:`pyproj.crs.coordinate_system.Cartesian2DCS`.
-        geodetic_crs: Any, optional
-            Input to create the Geodetic CRS, a :class:`GeographicCRS` or
-            anything accepted by :meth:`pyproj.crs.CRS.from_user_input`.
-        """
-        proj_crs_json = {
-            "$schema": "https://proj.org/schemas/v0.2/projjson.schema.json",
-            "type": "ProjectedCRS",
-            "name": name,
-            "base_crs": CRS.from_user_input(
-                geodetic_crs or GeographicCRS()
-            ).to_json_dict(),
-            "conversion": CoordinateOperation.from_user_input(
-                conversion
-            ).to_json_dict(),
-            "coordinate_system": CoordinateSystem.from_user_input(
-                cartesian_cs or Cartesian2DCS()
-            ).to_json_dict(),
-        }
-        super().__init__(proj_crs_json)
+    proj_crs_json = {
+        "$schema": "https://proj.org/schemas/v0.2/projjson.schema.json",
+        "type": "ProjectedCRS",
+        "name": name,
+        "base_crs": CRS.from_user_input(geodetic_crs or GeographicCRS()).to_json_dict(),
+        "conversion": CoordinateOperation.from_user_input(conversion).to_json_dict(),
+        "coordinate_system": CoordinateSystem.from_user_input(
+            cartesian_cs or Cartesian2DCS()
+        ).to_json_dict(),
+    }
+    return CRS(proj_crs_json)
 
 
-class VerticalCRS(CRS):
+def VerticalCRS(
+    name: str,
+    datum: Any,
+    vertical_cs: Any = None,
+    geoid_model: Optional[str] = None,
+) -> CRS:
     """
     .. versionadded:: 2.5.0
 
-    This class is for building a Vetical CRS.
+    Builds a Vetical CRS.
 
     .. warning:: geoid_model support only exists in PROJ >= 6.3.0
 
+    Parameters
+    ----------
+    name: str
+        The name of the Vertical CRS (e.g. NAVD88 height).
+    datum: Any
+        Anything accepted by :meth:`pyproj.crs.Datum.from_user_input`
+    vertical_cs: Any, optional
+        Input to create a Vertical Coordinate System accepted by
+        :meth:`pyproj.crs.CoordinateSystem.from_user_input`
+        or :class:`pyproj.crs.coordinate_system.VerticalCS`
+    geoid_model: str, optional
+        The name of the GEOID Model (e.g. GEOID12B).
     """
+    vert_crs_json = {
+        "$schema": "https://proj.org/schemas/v0.2/projjson.schema.json",
+        "type": "VerticalCRS",
+        "name": name,
+        "datum": Datum.from_user_input(datum).to_json_dict(),
+        "coordinate_system": CoordinateSystem.from_user_input(
+            vertical_cs or VerticalCS()
+        ).to_json_dict(),
+    }
+    if geoid_model is not None:
+        vert_crs_json["geoid_model"] = {"name": geoid_model}
 
-    def __init__(
-        self,
-        name: str,
-        datum: Any,
-        vertical_cs: Any = None,
-        geoid_model: Optional[str] = None,
-    ) -> None:
-        """
-        Parameters
-        ----------
-        name: str
-            The name of the Vertical CRS (e.g. NAVD88 height).
-        datum: Any
-            Anything accepted by :meth:`pyproj.crs.Datum.from_user_input`
-        vertical_cs: Any, optional
-            Input to create a Vertical Coordinate System accepted by
-            :meth:`pyproj.crs.CoordinateSystem.from_user_input`
-            or :class:`pyproj.crs.coordinate_system.VerticalCS`
-        geoid_model: str, optional
-            The name of the GEOID Model (e.g. GEOID12B).
-        """
-        vert_crs_json = {
-            "$schema": "https://proj.org/schemas/v0.2/projjson.schema.json",
-            "type": "VerticalCRS",
-            "name": name,
-            "datum": Datum.from_user_input(datum).to_json_dict(),
-            "coordinate_system": CoordinateSystem.from_user_input(
-                vertical_cs or VerticalCS()
-            ).to_json_dict(),
-        }
-        if geoid_model is not None:
-            vert_crs_json["geoid_model"] = {"name": geoid_model}
-
-        super().__init__(vert_crs_json)
+    return CRS(vert_crs_json)
 
 
-class CompoundCRS(CRS):
+def CompoundCRS(name: str, components: List[Any]) -> CRS:
     """
     .. versionadded:: 2.5.0
 
-    This class is for building a Compound CRS.
+    Builds a Compound CRS.
+
+    Parameters
+    ----------
+    name: str
+        The name of the Compound CRS.
+    components: List[Any], optional
+        List of CRS to create a Compound Coordinate System.
+        List of anything accepted by :meth:`pyproj.crs.CRS.from_user_input`
     """
-
-    def __init__(self, name: str, components: List[Any]) -> None:
-        """
-        Parameters
-        ----------
-        name: str
-            The name of the Compound CRS.
-        components: List[Any], optional
-            List of CRS to create a Compound Coordinate System.
-            List of anything accepted by :meth:`pyproj.crs.CRS.from_user_input`
-        """
-        compound_crs_json = {
-            "$schema": "https://proj.org/schemas/v0.2/projjson.schema.json",
-            "type": "CompoundCRS",
-            "name": name,
-            "components": [
-                CRS.from_user_input(component).to_json_dict()
-                for component in components
-            ],
-        }
-
-        super().__init__(compound_crs_json)
+    compound_crs_json = {
+        "$schema": "https://proj.org/schemas/v0.2/projjson.schema.json",
+        "type": "CompoundCRS",
+        "name": name,
+        "components": [
+            CRS.from_user_input(component).to_json_dict() for component in components
+        ],
+    }
+    return CRS(compound_crs_json)
 
 
-class BoundCRS(CRS):
+def BoundCRS(source_crs: Any, target_crs: Any, transformation: Any) -> CRS:
     """
     .. versionadded:: 2.5.0
 
-    This class is for building a Bound CRS.
+    Builds a Bound CRS.
+
+    Parameters
+    ----------
+    source_crs: Any
+        Input to create a source CRS.
+    target_crs: Any
+        Input to create the target CRS.
+    transformation: Any
+        Input to create the transformation.
     """
-
-    def __init__(self, source_crs: Any, target_crs: Any, transformation: Any) -> None:
-        """
-        Parameters
-        ----------
-        source_crs: Any
-            Input to create a source CRS.
-        target_crs: Any
-            Input to create the target CRS.
-        transformation: Any
-            Input to create the transformation.
-        """
-        bound_crs_json = {
-            "$schema": "https://proj.org/schemas/v0.2/projjson.schema.json",
-            "type": "BoundCRS",
-            "source_crs": CRS.from_user_input(source_crs).to_json_dict(),
-            "target_crs": CRS.from_user_input(target_crs).to_json_dict(),
-            "transformation": CoordinateOperation.from_user_input(
-                transformation
-            ).to_json_dict(),
-        }
-
-        super().__init__(bound_crs_json)
+    bound_crs_json = {
+        "$schema": "https://proj.org/schemas/v0.2/projjson.schema.json",
+        "type": "BoundCRS",
+        "source_crs": CRS.from_user_input(source_crs).to_json_dict(),
+        "target_crs": CRS.from_user_input(target_crs).to_json_dict(),
+        "transformation": CoordinateOperation.from_user_input(
+            transformation
+        ).to_json_dict(),
+    }
+    return CRS(bound_crs_json)

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,4 +1,5 @@
 import os
+import pickle
 from contextlib import contextmanager
 from distutils.version import LooseVersion
 from pathlib import Path
@@ -87,3 +88,14 @@ def get_wgs84_datum_name():
     if PROJ_GTE_8:
         return "World Geodetic System 1984 ensemble"
     return "World Geodetic System 1984"
+
+
+def assert_can_pickle(raw_obj, tmp_path):
+    file_path = tmp_path / "temporary.pickle"
+    with open(file_path, "wb") as f:
+        pickle.dump(raw_obj, f)
+
+    with open(file_path, "rb") as f:
+        unpickled = pickle.load(f)
+
+    assert raw_obj == unpickled

--- a/test/crs/test_crs.py
+++ b/test/crs/test_crs.py
@@ -20,6 +20,7 @@ from pyproj.transformer import TransformerGroup
 from test.conftest import (
     HAYFORD_ELLIPSOID_NAME,
     PROJ_GTE_8,
+    assert_can_pickle,
     get_wgs84_datum_name,
     grids_available,
 )
@@ -1475,3 +1476,7 @@ def test_to_3d(crs_input):
 def test_to_3d__name():
     crs_3d = CRS("EPSG:2056").to_3d(name="TEST")
     assert crs_3d.name == "TEST"
+
+
+def test_crs_pickle(tmp_path):
+    assert_can_pickle(CRS("epsg:4326"), tmp_path)

--- a/test/crs/test_crs_maker.py
+++ b/test/crs/test_crs_maker.py
@@ -19,22 +19,24 @@ from pyproj.crs.coordinate_operation import (
 from pyproj.crs.coordinate_system import Cartesian2DCS, Ellipsoidal3DCS, VerticalCS
 from pyproj.crs.datum import CustomDatum
 from pyproj.crs.enums import VerticalCSAxis
-from test.conftest import HAYFORD_ELLIPSOID_NAME
+from test.conftest import HAYFORD_ELLIPSOID_NAME, assert_can_pickle
 
 
-def test_make_projected_crs():
+def test_make_projected_crs(tmp_path):
     aeaop = AlbersEqualAreaConversion(0, 0)
     pc = ProjectedCRS(conversion=aeaop, name="Albers")
     assert pc.name == "Albers"
     assert pc.type_name == "Projected CRS"
     assert pc.coordinate_operation == aeaop
+    assert_can_pickle(pc, tmp_path)
 
 
-def test_make_geographic_crs():
+def test_make_geographic_crs(tmp_path):
     gc = GeographicCRS(name="WGS 84")
     assert gc.name == "WGS 84"
     assert gc.type_name == "Geographic 2D CRS"
     assert gc.to_authority() == ("OGC", "CRS84")
+    assert_can_pickle(gc, tmp_path)
 
 
 def test_make_geographic_3d_crs():
@@ -43,15 +45,16 @@ def test_make_geographic_3d_crs():
     assert gcrs.to_authority() == ("IGNF", "WGS84GEODD")
 
 
-def test_make_derived_geographic_crs():
+def test_make_derived_geographic_crs(tmp_path):
     conversion = RotatedLatitudeLongitudeConversion(o_lat_p=0, o_lon_p=0)
     dgc = DerivedGeographicCRS(base_crs=GeographicCRS(), conversion=conversion)
     assert dgc.name == "undefined"
     assert dgc.type_name == "Geographic 2D CRS"
     assert dgc.coordinate_operation == conversion
+    assert_can_pickle(dgc, tmp_path)
 
 
-def test_vertical_crs():
+def test_vertical_crs(tmp_path):
     vc = VerticalCRS(
         name="NAVD88 height",
         datum="North American Vertical Datum 1988",
@@ -61,6 +64,7 @@ def test_vertical_crs():
     assert vc.type_name == "Vertical CRS"
     assert vc.coordinate_system == VerticalCS()
     assert vc.to_json_dict()["geoid_model"]["name"] == "GEOID12B"
+    assert_can_pickle(vc, tmp_path)
 
 
 @pytest.mark.parametrize(
@@ -84,7 +88,7 @@ def test_vertical_crs__chance_cs_axis(axis):
     assert vc.coordinate_system == VerticalCS(axis=axis)
 
 
-def test_compund_crs():
+def test_compund_crs(tmp_path):
     vertcrs = VerticalCRS(
         name="NAVD88 height",
         datum="North American Vertical Datum 1988",
@@ -111,9 +115,10 @@ def test_compund_crs():
     assert compcrs.type_name == "Compound CRS"
     assert compcrs.sub_crs_list[0].type_name == "Projected CRS"
     assert compcrs.sub_crs_list[1].type_name == "Vertical CRS"
+    assert_can_pickle(compcrs, tmp_path)
 
 
-def test_bound_crs():
+def test_bound_crs(tmp_path):
     proj_crs = ProjectedCRS(conversion=UTMConversion(12))
     bound_crs = BoundCRS(
         source_crs=proj_crs,
@@ -126,6 +131,7 @@ def test_bound_crs():
     assert bound_crs.source_crs.coordinate_operation.name == "UTM zone 12N"
     assert bound_crs.coordinate_operation.towgs84 == [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0]
     assert bound_crs.target_crs.name == "WGS 84"
+    assert_can_pickle(bound_crs, tmp_path)
 
 
 def test_bound_crs__example():


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Closes #897
 - [x] Tests added
 - [x] Fully documented, including `history.rst` for all changes and `api/*.rst` for new API

Was thinking making the CRS maker classes into builders for the CRS objects would make things simpler for #847