### PR TITLE
REF: Make CRS methods inheritable

### DIFF
--- a/docs/history.rst
+++ b/docs/history.rst
@@ -4,6 +4,8 @@ Change Log
 Latest
 ------
 - REF: Handle deprecation of proj_context_set_autoclose_database (issue #866)
+- REF: Make CRS methods inheritable (issue #847)
+- ENH: Added :attr:`pyproj.crs.CRS.is_derived` (pull #902)
 - DOC: Improve FAQ text about CRS formats (issue #789)
 - BUG: Add PyPy cython array implementation (issue #854)
 - BUG: Fix spelling for

--- a/pyproj/_crs.pyx
+++ b/pyproj/_crs.pyx
@@ -2490,7 +2490,7 @@ cdef class _CRS(Base):
             )
 
         if not (
-            self.is_bound or proj_is_derived_crs(self.context, self.projobj)
+            self.is_bound or self.is_derived
         ):
             self._coordinate_operation = False
             return None
@@ -2970,6 +2970,18 @@ cdef class _CRS(Base):
         if self.is_bound:
             return self.source_crs.is_geocentric
         return self._type == PJ_TYPE_GEOCENTRIC_CRS
+
+    @property
+    def is_derived(self):
+        """
+        .. versionadded:: 3.2.0
+
+        Returns
+        -------
+        bool:
+            True if CRS is a Derived CRS.
+        """
+        return proj_is_derived_crs(self.context, self.projobj) == 1
 
     def _equals(self, _CRS other, bint ignore_axis_order):
         if ignore_axis_order:


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Closes #847
 - [ ] Tests added (TODO: More tests)
 - [x] Fully documented, including `history.rst` for all changes and `api/*.rst` for new API

Notes:
- The `from_*` methods were changed to bypass the `__init__` method. It also validates that it creates the expected type (Idea from https://github.com/pyproj4/pyproj/issues/847#issuecomment-843686871).
- The CRS properties were overridden to return a `CRS`. The reason for this is because the type of the CRS returned from that type is not guaranteed to always be the type of the original CRS.