### PR TITLE
CLN: Remove ignore_axis_order from CRS.is_exact_same as it was added by accident

### DIFF
--- a/docs/history.rst
+++ b/docs/history.rst
@@ -17,6 +17,7 @@ Latest
 - BUG: Update :class:`pyproj.enums.GeodIntermediateFlag` for future Python compatibility (issue #855)
 - BUG: Hide unnecessary PROJ ERROR from proj_crs_get_coordoperation (issue #873)
 - BUG: Fix pickling for CRS builder classes (issue #897)
+- CLN: Remove `ignore_axis_order` kwarg from :meth:`pyproj.crs.CRS.is_exact_same` as it was added by accident (pull #904)
 
 3.1.0
 -----

--- a/pyproj/crs/crs.py
+++ b/pyproj/crs/crs.py
@@ -885,7 +885,7 @@ class CRS:
                 cf_axis_list.extend(sub_crs.cs_to_cf())
         return cf_axis_list
 
-    def is_exact_same(self, other: Any, ignore_axis_order: bool = False) -> bool:
+    def is_exact_same(self, other: Any) -> bool:
         """
         Check if the CRS objects are the exact same.
 


### PR DESCRIPTION
 - [x] Fully documented, including `history.rst` for all changes and `api/*.rst` for new API

Not going to deprecate this one as is should never have been there and isn't in the docstrings.