### PR TITLE
PERF: Disable unnecessary copy in dtype conversion for buffer

### DIFF
--- a/docs/history.rst
+++ b/docs/history.rst
@@ -8,6 +8,7 @@ Latest
 - REF: Make CRS methods inheritable (issue #847)
 - ENH: Added :attr:`pyproj.crs.CRS.is_derived` (pull #902)
 - ENH: Added :attr:`pyproj.crs.GeocentricCRS` (pull #903)
+- PERF: Disable unnecessary copy in dtype conversion for buffer (pull #904)
 - DOC: Improve FAQ text about CRS formats (issue #789)
 - BUG: Add PyPy cython array implementation (issue #854)
 - BUG: Fix spelling for

--- a/pyproj/utils.py
+++ b/pyproj/utils.py
@@ -77,7 +77,7 @@ def _copytobuffer(xx: Any) -> Tuple[Any, bool, bool, bool]:
                 # Basemap issue
                 # https://github.com/matplotlib/basemap/pull/223/files
                 # (deal with input array in fortran order)
-                inx = xx.copy(order="C").astype("d")
+                inx = xx.copy(order="C").astype("d", copy=False)
                 # inx,isfloat,islist,istuple
                 return inx, False, False, False
             except Exception:


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->
 - [x] Fully documented, including `history.rst` for all changes and `api/*.rst` for new API

https://numpy.org/doc/stable/reference/generated/numpy.ndarray.astype.html

> By default, astype always returns a newly allocated array. If this is set to false, and the dtype, order, and subok requirements are satisfied, the input array is returned instead of a copy.

Since `copy` is explicitly called beforehand, `copy=False` should be safe.