### PR TITLE
CLN: remove numeric/numarrays support

### DIFF
--- a/docs/history.rst
+++ b/docs/history.rst
@@ -19,6 +19,7 @@ Latest
 - BUG: Hide unnecessary PROJ ERROR from proj_crs_get_coordoperation (issue #873)
 - BUG: Fix pickling for CRS builder classes (issue #897)
 - CLN: Remove `ignore_axis_order` kwarg from :meth:`pyproj.crs.CRS.is_exact_same` as it was added by accident (pull #904)
+- CLN: remove numeric/numarrays support (pull #908)
 
 3.1.0
 -----

--- a/pyproj/utils.py
+++ b/pyproj/utils.py
@@ -69,30 +69,16 @@ def _copytobuffer(xx: Any) -> Tuple[Any, bool, bool, bool]:
         if xx.shape == ():
             return _copytobuffer_return_scalar(xx)
         else:
-            try:
-                # typecast numpy arrays to double.
-                # (this makes a copy - which is crucial
-                #  since buffer is modified in place)
-                xx.dtype.char
-                # Basemap issue
-                # https://github.com/matplotlib/basemap/pull/223/files
-                # (deal with input array in fortran order)
-                inx = xx.copy(order="C").astype("d", copy=False)
-                # inx,isfloat,islist,istuple
-                return inx, False, False, False
-            except Exception:
-                try:  # perhaps they are Numeric/numarrays?
-                    # sorry, not tested yet.
-                    # i don't know Numeric/numarrays has `shape'.
-                    xx.typecode()
-                    inx = xx.astype("d")
-                    # inx,isfloat,islist,istuple
-                    return inx, False, False, False
-                except Exception:
-                    raise TypeError(
-                        "input must be an array, list, tuple, scalar, "
-                        "or have the __array__ method."
-                    )
+            # typecast numpy arrays to double.
+            # (this makes a copy - which is crucial
+            #  since buffer is modified in place)
+            xx.dtype.char
+            # Basemap issue
+            # https://github.com/matplotlib/basemap/pull/223/files
+            # (deal with input array in fortran order)
+            inx = xx.copy(order="C").astype("d", copy=False)
+            # inx,isfloat,islist,istuple
+            return inx, False, False, False
     else:
         # perhaps they are regular python arrays?
         if hasattr(xx, "typecode"):


### PR DESCRIPTION
These have been phased out by numpy. 
- https://wiki.python.org/moin/NumArray
- https://en.wikipedia.org/wiki/NumPy#History