### PR TITLE
REF: use astype("d", order="C") instead of copy(order="C").astype("d")

### DIFF
--- a/pyproj/utils.py
+++ b/pyproj/utils.py
@@ -100,9 +100,7 @@ def _copytobuffer(xxx: Any) -> Tuple[Any, DataType]:
             # (array scalars don't support buffer API)
             return _copytobuffer_return_scalar(xxx)
         # Use C order when copying to handle arrays in fortran order
-        # See: https://github.com/matplotlib/basemap/pull/223
-        xxx = xxx.copy(order="C").astype("d", copy=False)
-        return xxx, DataType.ARRAY
+        return xxx.astype("d", order="C"), DataType.ARRAY
     data_type = DataType.ARRAY
     if isinstance(xxx, array):
         xxx = array("d", xxx)

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -42,6 +42,14 @@ def test__copytobuffer__numpy_array(in_arr):
     )
 
 
+def test__copytobuffer__fortran_order():
+    data = numpy.ones((2, 4), dtype=numpy.float64, order="F")
+    converted_data, dtype = _copytobuffer(data)
+    assert data.flags.f_contiguous
+    assert not converted_data.flags.f_contiguous
+    assert converted_data.flags.c_contiguous
+
+
 def test__copytobuffer__invalid():
     with pytest.raises(TypeError):
         _copytobuffer("invalid")


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Closes #913
 - [x] Tests added
