### PR TITLE
ENH: Prepend Derived to CRS type name if CRS is derived

### DIFF
--- a/docs/history.rst
+++ b/docs/history.rst
@@ -3,6 +3,7 @@ Change Log
 
 Latest
 -------
+- BUG: Prepend "Derived" to CRS type name if CRS is derived (issue #932)
 
 3.2.1
 ------

--- a/pyproj/_crs.pxd
+++ b/pyproj/_crs.pxd
@@ -125,7 +125,7 @@ cdef class _CRS(Base):
     cdef PJ_TYPE _type
     cdef PJ_PROJ_INFO projpj_info
     cdef readonly str srs
-    cdef readonly str type_name
+    cdef readonly str _type_name
     cdef readonly Ellipsoid _ellipsoid
     cdef readonly object _area_of_use
     cdef readonly PrimeMeridian _prime_meridian

--- a/pyproj/_crs.pyx
+++ b/pyproj/_crs.pyx
@@ -2339,7 +2339,7 @@ cdef class _CRS(Base):
         self._geodetic_crs = None
         self._coordinate_system = None
         self._coordinate_operation = None
-        self.type_name = "undefined"
+        self._type_name = None
 
     def __init__(self, const char *proj_string):
         self.context = pyproj_context_create()
@@ -2356,9 +2356,23 @@ cdef class _CRS(Base):
         # set proj information
         self.srs = proj_string
         self._type = proj_get_type(self.projobj)
-        self.type_name = _CRS_TYPE_MAP[self._type]
         self._set_base_info()
         CRSError.clear()
+
+    @property
+    def type_name(self):
+        """
+        Returns
+        -------
+        str:
+            The name of the type of the CRS object.
+        """
+        if self._type_name is not None:
+            return self._type_name
+        self._type_name = _CRS_TYPE_MAP[self._type]
+        if self.is_derived:
+            self._type_name = f"Derived {self._type_name}"
+        return self._type_name
 
     @property
     def axis_info(self):

--- a/pyproj/crs/crs.py
+++ b/pyproj/crs/crs.py
@@ -1759,16 +1759,11 @@ class DerivedGeographicCRS(CustomConstructorCRS):
     This class is for building a Derived Geographic CRS
     """
 
-    _expected_types = ("Geographic CRS", "Geographic 2D CRS", "Geographic 3D CRS")
-
-    def _check_type(self):
-        """
-        This validates that the type of the CRS is expected
-        when using the from_* methods.
-        """
-        super()._check_type()
-        if not self.is_derived:
-            raise CRSError("CRS is not a Derived Geographic CRS")
+    _expected_types = (
+        "Derived Geographic CRS",
+        "Derived Geographic 2D CRS",
+        "Derived Geographic 3D CRS",
+    )
 
     def __init__(
         self,
@@ -1870,7 +1865,7 @@ class ProjectedCRS(CustomConstructorCRS):
     This class is for building a Projected CRS.
     """
 
-    _expected_types = ("Projected CRS",)
+    _expected_types = ("Projected CRS", "Derived Projected CRS")
 
     def __init__(
         self,

--- a/test/crs/test_crs.py
+++ b/test/crs/test_crs.py
@@ -1173,7 +1173,7 @@ def test_from_authority__ignf():
 
 def test_ignf_authority_repr():
     assert repr(CRS.from_authority("IGNF", "ETRS89UTM28")).startswith(
-        "<Projected CRS: IGNF:ETRS89UTM28>"
+        "<Derived Projected CRS: IGNF:ETRS89UTM28>"
     )
 
 

--- a/test/crs/test_crs_maker.py
+++ b/test/crs/test_crs_maker.py
@@ -40,7 +40,7 @@ def test_make_projected_crs(tmp_path):
     aeaop = AlbersEqualAreaConversion(0, 0)
     pc = ProjectedCRS(conversion=aeaop, name="Albers")
     assert pc.name == "Albers"
-    assert pc.type_name == "Projected CRS"
+    assert pc.type_name == "Derived Projected CRS"
     assert pc.coordinate_operation == aeaop
     assert_can_pickle(pc, tmp_path)
 
@@ -105,7 +105,7 @@ def test_make_derived_geographic_crs(tmp_path):
     conversion = RotatedLatitudeLongitudeConversion(o_lat_p=0, o_lon_p=0)
     dgc = DerivedGeographicCRS(base_crs=GeographicCRS(), conversion=conversion)
     assert dgc.name == "undefined"
-    assert dgc.type_name == "Geographic 2D CRS"
+    assert dgc.type_name == "Derived Geographic 2D CRS"
     assert dgc.coordinate_operation == conversion
     assert dgc.is_derived
     assert_can_pickle(dgc, tmp_path)
@@ -113,7 +113,7 @@ def test_make_derived_geographic_crs(tmp_path):
 
 def test_derived_geographic_crs__from_methods():
     crs_str = "+proj=ob_tran +o_proj=longlat +o_lat_p=0 +o_lon_p=0 +lon_0=0"
-    with pytest.raises(CRSError, match="CRS is not a Derived Geographic CRS"):
+    with pytest.raises(CRSError, match="Invalid type Geographic 2D CRS"):
         DerivedGeographicCRS.from_epsg(4326)
     assert_maker_inheritance_valid(
         DerivedGeographicCRS.from_string(crs_str), DerivedGeographicCRS
@@ -240,7 +240,7 @@ def test_compund_crs(tmp_path):
     )
     assert compcrs.name == "NAD83 / Pennsylvania South + NAVD88 height"
     assert compcrs.type_name == "Compound CRS"
-    assert compcrs.sub_crs_list[0].type_name == "Projected CRS"
+    assert compcrs.sub_crs_list[0].type_name == "Derived Projected CRS"
     assert compcrs.sub_crs_list[1].type_name == "Vertical CRS"
     assert_can_pickle(compcrs, tmp_path)
 


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Closes #932
 - [x] Tests updated
 - [x] Fully documented, including `history.rst` for all changes and `api/*.rst` for new API
