### PR TITLE
BUG: Return multiple authorities with pyproj.crs.CRS.list_authority

### DIFF
--- a/docs/history.rst
+++ b/docs/history.rst
@@ -5,6 +5,7 @@ Latest
 ------
 - REF: declare specific python types in cython (pull #928)
 - REF: Use cython string decoding (pull #929)
+- BUG: Return multiple authorities with :attr:`pyproj.crs.CRS.list_authority` (pull #943)
 
 3.2.0
 ------

--- a/pyproj/_crs.pyx
+++ b/pyproj/_crs.pyx
@@ -2802,8 +2802,8 @@ cdef class _CRS(Base):
         # get list of possible matching projections
         cdef PJ_OBJ_LIST *proj_list = NULL
         cdef int *c_out_confidence_list = NULL
-        cdef int out_confidence = -9999
         cdef int num_proj_objects = -9999
+        cdef bytes b_auth_name
         cdef char *user_auth_name = NULL
         cdef int iii = 0
 
@@ -2841,8 +2841,8 @@ cdef class _CRS(Base):
                 if out_confidence_list[iii] < min_confidence:
                     continue
                 proj = proj_list_get(self.context, proj_list, iii)
-                code = proj_get_id_code(proj, iii)
-                out_auth_name = proj_get_id_auth_name(proj, iii)
+                code = proj_get_id_code(proj, 0)
+                out_auth_name = proj_get_id_auth_name(proj, 0)
                 if out_auth_name != NULL and code != NULL:
                     authority_list.append(
                         AuthorityMatchInfo(

--- a/test/crs/test_crs.py
+++ b/test/crs/test_crs.py
@@ -1536,3 +1536,9 @@ def test_list_authority():
     assert CRS("+proj=utm +zone=15").list_authority() == [
         AuthorityMatchInfo(auth_name="EPSG", code="32615", confidence=70)
     ]
+
+
+def test_list_authority__multiple():
+    auth_list = CRS("+proj=longlat").list_authority()
+    assert AuthorityMatchInfo(auth_name="OGC", code="CRS84", confidence=70) in auth_list
+    assert AuthorityMatchInfo(auth_name="EPSG", code="4326", confidence=70) in auth_list


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Tests added
 - [x] Fully documented, including `history.rst` for all changes and `api/*.rst` for new API
