### PR TITLE
BUG: CRS CF conversions ensure Pole rotation (netCDF CF convention) conversion works

### DIFF
--- a/docs/history.rst
+++ b/docs/history.rst
@@ -7,6 +7,7 @@ Latest
 - REF: Use cython string decoding (pull #929)
 - BUG: Return multiple authorities with :attr:`pyproj.crs.CRS.list_authority` (pull #943)
 - BUG: CRS CF conversions ensure lon_0 = north_pole_grid_longitude + 180 (issue #927)
+- BUG: CRS CF conversions ensure Pole rotation (netCDF CF convention) conversion works (issue #927)
 
 3.2.0
 ------

--- a/pyproj/crs/_cf1x8.py
+++ b/pyproj/crs/_cf1x8.py
@@ -632,6 +632,27 @@ def _rotated_latitude_longitude__to_cf(conversion):
     }
 
 
+def _pole_rotation_netcdf__to_cf(conversion):
+    """
+    http://cfconventions.org/cf-conventions/cf-conventions.html#_rotated_pole
+
+    https://github.com/OSGeo/PROJ/pull/2835
+    """
+    params = _to_dict(conversion)
+    return {
+        "grid_mapping_name": "rotated_latitude_longitude",
+        "grid_north_pole_latitude": params[
+            "grid_north_pole_latitude_(netcdf_cf_convention)"
+        ],
+        "grid_north_pole_longitude": params[
+            "grid_north_pole_longitude_(netcdf_cf_convention)"
+        ],
+        "north_pole_grid_longitude": params[
+            "north_pole_grid_longitude_(netcdf_cf_convention)"
+        ],
+    }
+
+
 _INVERSE_GRID_MAPPING_NAME_MAP = {
     "albers_equal_area": _albers_conical_equal_area__to_cf,
     "modified_azimuthal_equidistant": _azimuthal_equidistant__to_cf,
@@ -658,4 +679,5 @@ _INVERSE_GEOGRAPHIC_GRID_MAPPING_NAME_MAP = {
     "proj ob_tran o_proj=lonlat": _rotated_latitude_longitude__to_cf,
     "proj ob_tran o_proj=latlon": _rotated_latitude_longitude__to_cf,
     "proj ob_tran o_proj=latlong": _rotated_latitude_longitude__to_cf,
+    "pole rotation (netcdf cf convention)": _pole_rotation_netcdf__to_cf,
 }

--- a/test/crs/test_crs_cf.py
+++ b/test/crs/test_crs_cf.py
@@ -422,6 +422,61 @@ def test_cf_rotated_latlon__grid():
     }
 
 
+def test_rotated_pole_to_cf():
+    rotated_pole_wkt = (
+        'GEOGCRS["undefined",\n'
+        '    BASEGEOGCRS["Unknown datum based upon the GRS 1980 ellipsoid",\n'
+        '        DATUM["Not specified (based on GRS 1980 ellipsoid)",\n'
+        '            ELLIPSOID["GRS 1980",6378137,298.257222101,\n'
+        '                LENGTHUNIT["metre",1]]],\n'
+        '        PRIMEM["Greenwich",0,\n'
+        '            ANGLEUNIT["degree",0.0174532925199433]]],\n'
+        '    DERIVINGCONVERSION["Pole rotation (netCDF CF convention)",\n'
+        '        METHOD["Pole rotation (netCDF CF convention)"],\n'
+        '        PARAMETER["Grid north pole latitude (netCDF CF '
+        'convention)",2,\n'
+        '            ANGLEUNIT["degree",0.0174532925199433,\n'
+        '                ID["EPSG",9122]]],\n'
+        '        PARAMETER["Grid north pole longitude (netCDF CF '
+        'convention)",3,\n'
+        '            ANGLEUNIT["degree",0.0174532925199433,\n'
+        '                ID["EPSG",9122]]],\n'
+        '        PARAMETER["North pole grid longitude (netCDF CF '
+        'convention)",4,\n'
+        '            ANGLEUNIT["degree",0.0174532925199433,\n'
+        '                ID["EPSG",9122]]]],\n'
+        "    CS[ellipsoidal,2],\n"
+        '        AXIS["geodetic latitude (Lat)",north,\n'
+        "            ORDER[1],\n"
+        '            ANGLEUNIT["degree",0.0174532925199433,\n'
+        '                ID["EPSG",9122]]],\n'
+        '        AXIS["geodetic longitude (Lon)",east,\n'
+        "            ORDER[2],\n"
+        '            ANGLEUNIT["degree",0.0174532925199433,\n'
+        '                ID["EPSG",9122]]]]'
+    )
+    crs = CRS(rotated_pole_wkt)
+    expected_cf = {
+        "semi_major_axis": 6378137.0,
+        "semi_minor_axis": 6356752.314140356,
+        "inverse_flattening": 298.257222101,
+        "reference_ellipsoid_name": "GRS 1980",
+        "longitude_of_prime_meridian": 0.0,
+        "prime_meridian_name": "Greenwich",
+        "geographic_crs_name": "undefined",
+        "grid_mapping_name": "rotated_latitude_longitude",
+        "grid_north_pole_latitude": 2.0,
+        "grid_north_pole_longitude": 3.0,
+        "north_pole_grid_longitude": 4.0,
+        "horizontal_datum_name": "Not specified (based on GRS 1980 ellipsoid)",
+    }
+    cf_dict = crs.to_cf()
+    assert cf_dict.pop("crs_wkt").startswith("GEOGCRS[")
+    assert cf_dict == expected_cf
+    # test roundtrip
+    _test_roundtrip(expected_cf, "GEOGCRS[")
+
+
 def test_cf_lambert_conformal_conic_1sp():
     crs = CRS.from_cf(
         dict(


### PR DESCRIPTION


<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Part of #927
 - [x] Tests added
 - [x] Fully documented, including `history.rst` for all changes and `api/*.rst` for new API
