### PR TITLE
ENH: Add support for transforming bounds at the poles

### DIFF
--- a/docs/history.rst
+++ b/docs/history.rst
@@ -5,6 +5,7 @@ Latest
 -------
 - BUG: Prepend "Derived" to CRS type name if CRS is derived (issue #932)
 - BUG: Improved handling of inf values in :attr:`pyproj.transformer.Transformer.transform_bounds` (pull #961)
+- ENH: Add support for transforming bounds at the poles in :attr:`pyproj.transformer.Transformer.transform_bounds` (pull #962)
 
 3.2.1
 ------

--- a/pyproj/transformer.py
+++ b/pyproj/transformer.py
@@ -895,6 +895,10 @@ class Transformer:
                     )
                 return shapely.geometry.box(left, bottom, right, top)
 
+        When projecting from polar projections to geographic,
+        lon, lat output order is required. The 'always_xy' flag
+        in the 'from_crs' constructor can help ensure that is the case.
+
 
         Parameters
         ----------

--- a/test/test_transformer.py
+++ b/test/test_transformer.py
@@ -1374,6 +1374,38 @@ def test_transform_bounds__noop_geographic():
     )
 
 
+def test_transform_bounds__north_pole():
+    crs = CRS("EPSG:32661")
+    transformer = Transformer.from_crs(crs, "EPSG:4326", always_xy=True)
+    bounds = transformer.transform_bounds(*crs.area_of_use.bounds, direction="INVERSE")
+    assert_almost_equal(
+        bounds,
+        (-1371213.76, -1405880.72, 5371213.76, 5405880.72),
+        decimal=0,
+    )
+    assert_almost_equal(
+        transformer.transform_bounds(*bounds),
+        (-180.0, 48.656, 180.0, 90.0),
+        decimal=0,
+    )
+
+
+def test_transform_bounds__south_pole():
+    crs = CRS("EPSG:32761")
+    transformer = Transformer.from_crs(crs, "EPSG:4326", always_xy=True)
+    bounds = transformer.transform_bounds(*crs.area_of_use.bounds, direction="INVERSE")
+    assert_almost_equal(
+        bounds,
+        (-1371213.76, -1405880.72, 5371213.76, 5405880.72),
+        decimal=0,
+    )
+    assert_almost_equal(
+        transformer.transform_bounds(*bounds),
+        (-180.0, -90.0, 180.0, -48.656),
+        decimal=0,
+    )
+
+
 @pytest.mark.parametrize("inplace", [True, False])
 def test_transform__fortran_order(inplace):
     lons, lats = np.arange(-180, 180, 20), np.arange(-90, 90, 10)


### PR DESCRIPTION
Script:
```python
from pyproj import CRS, Transformer
crs = CRS("EPSG:32661")
tr = Transformer.from_crs(crs, 4326, always_xy=True)
bounds = tr.transform_bounds(*crs.area_of_use.bounds, direction="INVERSE")
print(crs)
print(crs.area_of_use.bounds)
print(bounds)
print(tr.transform_bounds(*bounds))
crs = CRS("EPSG:32761")
tr = Transformer.from_crs(crs, 4326, always_xy=True)
bounds = tr.transform_bounds(*crs.area_of_use.bounds, direction="INVERSE")
print(crs)
print(crs.area_of_use.bounds)
print(bounds)
print(tr.transform_bounds(*bounds))
```

Current version (3.2.1)
```
EPSG:32661
(-180.0, 60.0, 180.0, 90.0)
(-1371213.7625429356, -1405880.71737131, 5371213.762542935, 5405880.71737131)
(-180.0, 48.65640565307887, 174.85815802748752, 60.292277663390834)
EPSG:32761
(-180.0, -90.0, 180.0, -60.0)
(-1371213.7625429356, -1405880.71737131, 5371213.762542935, 5405880.71737131)
(-174.8581580274875, -60.292277663390834, 180.0, -48.65640565307887)
```
With this PR:
```
EPSG:32661
(-180.0, 60.0, 180.0, 90.0)
(-1371213.7625429356, -1405880.71737131, 5371213.762542935, 5405880.71737131)
(-180.0, 48.65640565307887, 180.0, 90.0)
EPSG:32761
(-180.0, -90.0, 180.0, -60.0)
(-1371213.7625429356, -1405880.71737131, 5371213.762542935, 5405880.71737131)
(-180.0, -90.0, 180.0, -48.65640565307887)

```