### PR TITLE
DEP: Disable pypy tests & make python pin 3.8+

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -44,10 +44,11 @@ jobs:
             python-version: 3.8
             python-implementation: python
             proj-version: 8.1
-          - os: ubuntu-latest
-            python-version: '*'
-            python-implementation: pypy
-            proj-version: '*'
+          # disabled until pypy has 3.8+ version
+          # - os: ubuntu-latest
+          #   python-version: '*'
+          #   python-implementation: pypy
+          #   proj-version: '*'
     steps:
       - uses: actions/checkout@v2
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,7 @@ project_urls =
 [options]
 zip_safe = False # https://mypy.readthedocs.io/en/stable/installed_packages.html
 packages = pyproj,pyproj.crs
-python_requires = >=3.7
+python_requires = >=3.8
 install_requires =
     certifi
 


### PR DESCRIPTION
Continuation of #972

After some thought, I think not increasing the Python pin in setup.py will cause confusion/troubles for CPython users without wheels. So, I think pypy support will have to be dropped until pypy supports newer Python versions.