### PR TITLE
CI: Use python 3.9 for lint checks

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -14,6 +14,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
+        with:
+            python-version: 3.9
       - uses: pre-commit/action@v2.0.0
       - name: Install mypy
         run: |


### PR DESCRIPTION
https://github.com/pyproj4/pyproj/runs/4057654052

Python 3.10 having issues with flake8 & cython for some reason.