### PR TITLE
Add missing definition of cop to docs

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -175,7 +175,8 @@ This is just a small subset of what is available.
     - Ellipsoid: undefined
     - Prime Meridian: undefined
     ]
-    >>> print(crs.sub_crs_list[0].coordinate_operation.to_wkt(pretty=True))
+    >>> cop = crs.sub_crs_list[0].coordinate_operation
+    >>> print(cop.to_wkt(pretty=True))
     CONVERSION["Finland Uniform Coordinate System",
         METHOD["Transverse Mercator",
             ID["EPSG",9807]],


### PR DESCRIPTION
Add a missing definition of ``cop`` to the getting started part of the
documentation.

 - [x] Closes #994
 - [x] Fully documented, including `history.rst` for all changes and `api/*.rst` for new API
