### PR TITLE
crs.py: remove @abstractmethod decorator

### DIFF
--- a/pyproj/crs/crs.py
+++ b/pyproj/crs/crs.py
@@ -7,7 +7,6 @@ import json
 import re
 import threading
 import warnings
-from abc import abstractmethod
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 from pyproj._crs import (
@@ -1591,7 +1590,6 @@ class CustomConstructorCRS(CRS):
     """
 
     @property
-    @abstractmethod
     def _expected_types(self) -> Tuple[str, ...]:
         """
         These are the type names of the CRS class


### PR DESCRIPTION
According to the documentation for the `@abstractmethod` decorator:

> Using this decorator requires that the class's metaclass is
> ABCMeta or is derived from it.

(source: https://docs.python.org/3/library/abc.html#abc.abstractmethod)

Since `CustomConstructorCRS` and `CRS` are not defined as abstract
classes, using the `@abstractmethod` decorator does not actually do
anything and should be removed.

<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [ ] Tests added
 - [ ] Fully documented, including `history.rst` for all changes and `api/*.rst` for new API
