### PR TITLE
BUG: Reorder deps in show_versions for setuptools issue

### DIFF
--- a/pyproj/_show_versions.py
+++ b/pyproj/_show_versions.py
@@ -81,7 +81,7 @@ def _get_deps_info():
     deps_info: dict
         version information on relevant Python libraries
     """
-    deps = ["certifi", "pip", "setuptools", "Cython"]
+    deps = ["certifi", "Cython", "setuptools", "pip"]
 
     def get_version(module):
         try:


### PR DESCRIPTION
Attempt based on suggestion: https://github.com/pandas-dev/pandas/issues/44980#issuecomment-1001237377

 - [x] Closes #1017
 - [ ] Fully documented, including `history.rst` for all changes and `api/*.rst` for new API
