### PR TITLE
DEP: Remove sphinx pin

### DIFF
--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,3 +1,3 @@
-sphinx < 3.5.0
+sphinx
 sphinx_rtd_theme
 sphinx-argparse


### PR DESCRIPTION
Latest jinja2 breaks docs build due to removal of deprecated features. Updated sphinx may help and previous issues requiring the pin are likely resolved.