### PR TITLE
CI: Use cibuildwheel for OSX

### DIFF
--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -1,0 +1,58 @@
+name: Wheels
+
+on:
+  push:
+    branches: [ main ]
+  release:
+    types: [ created ]
+
+jobs:
+  build_wheels:
+    name: Build ${{ matrix.arch }} wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    env:
+      PROJ_VERSION: "8.2.0"
+      PROJ_DIR: ${GITHUB_WORKSPACE}/pyproj/proj_dir
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+        - os: macos-10.15
+          arch: x86_64
+          cmake_osx_architectures: x86_64
+        # - os: macos-10.15
+        #   arch: arm64
+        #   cmake_osx_architectures: arm64
+        # - os: macos-10.15
+        #   arch: universal2
+        #   cmake_osx_architectures: "x86_64;arm64"
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-python@v2
+
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v2.3.1
+        env:
+          CIBW_ARCHS: ${{ matrix.arch }}
+          CIBW_ENVIRONMENT_MACOS:
+            PROJ_WHEEL=true
+            PROJ_VERSION=${{ env.PROJ_VERSION }}
+            PROJ_DIR=${{ env.PROJ_DIR }}
+            MACOSX_DEPLOYMENT_TARGET=10.9
+            CMAKE_OSX_ARCHITECTURES='${{ matrix.cmake_osx_architectures }}'
+            LDFLAGS="${LDFLAGS} -Wl,-rpath,${{ env.PROJ_DIR }}/lib"
+          CIBW_BEFORE_ALL: bash ./ci/proj-compile-wheels.sh
+          CIBW_TEST_REQUIRES: cython pytest oldest-supported-numpy pandas xarray
+          CIBW_BEFORE_TEST: python -m pip install shapely~=1.7.1 || echo "Shapely install failed"
+          CIBW_TEST_COMMAND: >
+            pyproj -v &&
+            python -c "import pyproj; pyproj.Proj(init='epsg:4269')"  &&
+            cp -r {package}/test . &&
+            PROJ_NETWORK=ON python -m pytest test -v -s
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          path: ./wheelhouse/*.whl
+          retention-days: 5

--- a/ci/proj-compile-wheels.sh
+++ b/ci/proj-compile-wheels.sh
@@ -1,0 +1,267 @@
+# INSTALL PROJ & DEPENDENCIES FOR WHEELS
+# Test for macOS with [ -n "$IS_MACOS" ]
+SQLITE_VERSION=3350500
+LIBTIFF_VERSION=4.3.0
+CURL_VERSION=7.76.1
+NGHTTP2_VERSION=1.43.0
+
+
+# ------------------------------------------
+# From: https://github.com/multi-build/multibuild/
+# ------------------------------------------
+BUILD_PREFIX="${BUILD_PREFIX:-/usr/local}"
+
+export CPPFLAGS_BACKUP="$CPPFLAGS"
+export LIBRARY_PATH_BACKUP="$LIBRARY_PATH"
+export PKG_CONFIG_PATH_BACKUP="$PKG_CONFIG_PATH"
+
+function update_env_for_build_prefix {
+  # Promote BUILD_PREFIX on search path to any newly built libs
+  export CPPFLAGS="-I$BUILD_PREFIX/include $CPPFLAGS_BACKUP"
+  export LIBRARY_PATH="$BUILD_PREFIX/lib:$LIBRARY_PATH_BACKUP"
+  export PKG_CONFIG_PATH="$BUILD_PREFIX/lib/pkgconfig/:$PKG_CONFIG_PATH_BACKUP"
+  # Add binary path for configure utils etc
+  export PATH="$BUILD_PREFIX/bin:$PATH"
+}
+
+if [ $(uname) == "Darwin" ]; then
+  IS_MACOS=1;
+fi
+
+function rm_mkdir {
+    # Remove directory if present, then make directory
+    local path=$1
+    if [ -z "$path" ]; then echo "Need not-empty path"; exit 1; fi
+    if [ -d "$path" ]; then rm -rf $path; fi
+    mkdir $path
+}
+
+function untar {
+    local in_fname=$1
+    if [ -z "$in_fname" ];then echo "in_fname not defined"; exit 1; fi
+    local extension=${in_fname##*.}
+    case $extension in
+        tar) tar -xf $in_fname ;;
+        gz|tgz) tar -zxf $in_fname ;;
+        bz2) tar -jxf $in_fname ;;
+        zip) unzip -qq $in_fname ;;
+        xz) if [ -n "$IS_MACOS" ]; then
+              tar -xf $in_fname
+            else
+              if [[ ! $(type -P "unxz") ]]; then
+                echo xz must be installed to uncompress file; exit 1
+              fi
+              unxz -c $in_fname | tar -xf -
+            fi ;;
+        *) echo Did not recognize extension $extension; exit 1 ;;
+    esac
+}
+
+function suppress {
+    # Run a command, show output only if return code not 0.
+    # Takes into account state of -e option.
+    # Compare
+    # https://unix.stackexchange.com/questions/256120/how-can-i-suppress-output-only-if-the-command-succeeds#256122
+    # Set -e stuff agonized over in
+    # https://unix.stackexchange.com/questions/296526/set-e-in-a-subshell
+    local tmp=$(mktemp tmp.XXXXXXXXX) || return
+    local errexit_set
+    echo "Running $@"
+    if [[ $- = *e* ]]; then errexit_set=true; fi
+    set +e
+    ( if [[ -n $errexit_set ]]; then set -e; fi; "$@"  > "$tmp" 2>&1 ) ; ret=$?
+    [ "$ret" -eq 0 ] || cat "$tmp"
+    rm -f "$tmp"
+    if [[ -n $errexit_set ]]; then set -e; fi
+    return "$ret"
+}
+
+function install_rsync {
+    # install rsync via package manager
+    if [ -n "$IS_MACOS" ]; then
+        # macOS. The colon in the next line is the null command
+        :
+    elif [[ $MB_ML_VER == "_2_24" ]]; then
+        # debian:9 based distro
+        [[ $(type -P rsync) ]] || apt-get install -y rsync
+    else
+        # centos based distro
+        [[ $(type -P rsync) ]] || yum_install rsync
+    fi
+}
+
+function fetch_unpack {
+    # Fetch input archive name from input URL
+    # Parameters
+    #    url - URL from which to fetch archive
+    #    archive_fname (optional) archive name
+    #
+    # Echos unpacked directory and file names.
+    #
+    # If `archive_fname` not specified then use basename from `url`
+    # If `archive_fname` already present at download location, use that instead.
+    local url=$1
+    if [ -z "$url" ];then echo "url not defined"; exit 1; fi
+    local archive_fname=${2:-$(basename $url)}
+    local arch_sdir="${ARCHIVE_SDIR:-archives}"
+    if [ -z "$IS_MACOS" ]; then
+        local extension=${archive_fname##*.}
+        if [ "$extension" == "xz" ]; then
+            ensure_xz
+        fi
+    fi
+    # Make the archive directory in case it doesn't exist
+    mkdir -p $arch_sdir
+    local out_archive="${arch_sdir}/${archive_fname}"
+    # If the archive is not already in the archives directory, get it.
+    if [ ! -f "$out_archive" ]; then
+        # Source it from multibuild archives if available.
+        local our_archive="${MULTIBUILD_DIR}/archives/${archive_fname}"
+        if [ -f "$our_archive" ]; then
+            ln -s $our_archive $out_archive
+        else
+            # Otherwise download it.
+            curl -L $url > $out_archive
+        fi
+    fi
+    # Unpack archive, refreshing contents, echoing dir and file
+    # names.
+    rm_mkdir arch_tmp
+    install_rsync
+    (cd arch_tmp && \
+        untar ../$out_archive && \
+        ls -1d * &&
+        rsync --delete -ah * ..)
+}
+
+function build_simple {
+    # Example: build_simple libpng $LIBPNG_VERSION \
+    #               https://download.sourceforge.net/libpng tar.gz \
+    #               --additional --configure --arguments
+    local name=$1
+    local version=$2
+    local url=$3
+    local ext=${4:-tar.gz}
+    local configure_args=${@:5}
+    if [ -e "${name}-stamp" ]; then
+        return
+    fi
+    local name_version="${name}-${version}"
+    local archive=${name_version}.${ext}
+    fetch_unpack $url/$archive
+    (cd $name_version \
+        && ./configure --prefix=$BUILD_PREFIX $configure_args \
+        && make -j4 \
+        && make install)
+    touch "${name}-stamp"
+}
+
+function get_modern_cmake {
+    # Install cmake >= 2.8
+    local cmake=cmake
+    if [ -n "$IS_MACOS" ]; then
+        brew install cmake > /dev/null
+    elif [[ $MB_ML_VER == "_2_24" ]]; then
+        # debian:9 based distro
+        apt-get install -y cmake
+    else
+        if [ "`yum search cmake | grep ^cmake28\.`" ]; then
+            cmake=cmake28
+        fi
+        # centos based distro
+        yum_install $cmake > /dev/null
+    fi
+    echo $cmake
+}
+
+function build_zlib {
+    # Gives an old but safe version
+    if [ -n "$IS_MACOS" ]; then return; fi  # OSX has zlib already
+    if [ -e zlib-stamp ]; then return; fi
+    if [[ $MB_ML_VER == "_2_24" ]]; then
+        # debian:9 based distro
+        apt-get install -y zlib1g-dev
+    else
+        #centos based distro
+        yum_install zlib-devel
+    fi
+    touch zlib-stamp
+}
+# ------------------------------------------
+
+
+function build_nghttp2 {
+    if [ -e nghttp2-stamp ]; then return; fi
+    fetch_unpack https://github.com/nghttp2/nghttp2/releases/download/v${NGHTTP2_VERSION}/nghttp2-${NGHTTP2_VERSION}.tar.gz
+    (cd nghttp2-${NGHTTP2_VERSION}  \
+        && ./configure --enable-lib-only --prefix=$BUILD_PREFIX \
+        && make -j4 \
+        && make install)
+    touch nghttp2-stamp
+}
+
+function build_curl_ssl {
+    if [ -e curl-stamp ]; then return; fi
+    CFLAGS="$CFLAGS -g -O2"
+    CXXFLAGS="$CXXFLAGS -g -O2"
+    suppress build_nghttp2
+    local flags="--prefix=$BUILD_PREFIX --with-nghttp2=$BUILD_PREFIX --with-zlib=$BUILD_PREFIX"
+    if [ -n "$IS_MACOS" ]; then
+        flags="$flags --with-darwinssl"
+    else  # manylinux
+        suppress build_openssl
+        flags="$flags --with-ssl"
+        LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$BUILD_PREFIX/lib
+    fi
+    fetch_unpack https://curl.se/download/curl-${CURL_VERSION}.tar.gz
+    (cd curl-${CURL_VERSION} \
+        && if [ -z "$IS_MACOS" ]; then \
+        LIBS=-ldl ./configure $flags; else \
+        ./configure $flags; fi\
+        && make -j4 \
+        && make install)
+    touch curl-stamp
+}
+
+
+function build_libtiff {
+    if [ -e libtiff-stamp ]; then return; fi
+    build_simple tiff $LIBTIFF_VERSION https://download.osgeo.org/libtiff
+    touch libtiff-stamp
+}
+
+function build_sqlite {
+    if [ -z "$IS_MACOS" ]; then
+        CFLAGS="$CFLAGS -DHAVE_PREAD64 -DHAVE_PWRITE64"
+    fi
+    if [ -e sqlite-stamp ]; then return; fi
+    build_simple sqlite-autoconf $SQLITE_VERSION https://www.sqlite.org/2021
+    touch sqlite-stamp
+}
+
+function build_proj {
+    if [ -e proj-stamp ]; then return; fi
+    get_modern_cmake
+    fetch_unpack https://download.osgeo.org/proj/proj-${PROJ_VERSION}.tar.gz
+    suppress build_curl_ssl
+    (cd proj-${PROJ_VERSION:0:5} \
+        && cmake . \
+        -DCMAKE_INSTALL_PREFIX=$PROJ_DIR \
+        -DBUILD_SHARED_LIBS=ON \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DENABLE_IPO=ON \
+        -DBUILD_APPS:BOOL=OFF \
+        -DBUILD_TESTING:BOOL=OFF \
+        -DCMAKE_PREFIX_PATH=$BUILD_PREFIX \
+        -DCMAKE_INSTALL_LIBDIR=lib \
+        && cmake --build . -j$(nproc) \
+        && cmake --install .)
+    touch proj-stamp
+}
+
+# Run installation process
+update_env_for_build_prefix
+suppress build_zlib
+suppress build_sqlite
+suppress build_libtiff
+build_proj


### PR DESCRIPTION
cibuildwheel seems to have become more official: https://github.com/pypa/cibuildwheel
Probably a good idea to migrate to using it as it will likely be better supported long-term. This is just the first step in that process.
Source for some ideas: https://github.com/pygeos/pygeos/blob/0835379a5bc534be63037696b1b70cf4337e3841/.github/workflows/release.yml

What this PR does:  adds X86_64 builds for OSX
This is helpful because the current wheels claim to be universal, but they are not.

Related:
- https://github.com/pyproj4/pyproj-wheels/issues/46
- https://github.com/pyproj4/pyproj-wheels/issues/42
- #1027 