### PR TITLE
DOC: Add manylinux2014 notes

### DIFF
--- a/docs/history.rst
+++ b/docs/history.rst
@@ -3,6 +3,7 @@ Change Log
 
 Latest
 -------
+- WHL: Wheels for Linux are manylinux2014 (pip 19.3+)
 - BUG: Complete database stub file with query_utm_crs_info() signature (issue #1044)
 - BUG: Reorder deps in show_versions for setuptools issue (issue #1017)
 - BUG: remove CustomConstructorCRS @abstractmethod decorator (pull #1018)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -9,11 +9,10 @@ GitHub Repository: https://github.com/pyproj4/pyproj
 
 .. note:: Minimum supported Python version is 3.8
 
+.. note:: Linux (manylinux2014) wheels require pip 19.3+
+
 .. note:: pyproj 3 wheels do not include transformation grids.
           For migration assistance see: :ref:`transformation_grids`
-
-.. note:: pyproj 3+ no longer supports manylinux1 wheels.
-          pip>=19.0 is required to install manylinux2010 wheels.
 
 
 .. toctree::

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -12,14 +12,15 @@ The easiest methods for installing pyproj are:
 
       pip install pyproj
 
-  .. note:: pyproj 3+ no longer supports manylinux1 wheels.
-            pip>=19.0 is required to install manylinux2010 wheels.
+  .. note:: Linux (manylinux2014) wheels require pip 19.3+
 
   .. note:: pyproj 3+ wheels do not include transformation grids.
             For migration assistance see: :ref:`transformation_grids`
 
 
-  - The MacOS and Linux wheels are powered by `multibuild by Matthew Brett <https://github.com/matthew-brett/multibuild>`__
+  - The MacOS and Linux wheels are powered by
+    `cibuildwheel <https://github.com/pypa/cibuildwheel>`__
+    & `multibuild <https://github.com/multi-build/multibuild>`__
   - The Windows wheels are built by `Christoph Gohlke <https://www.lfd.uci.edu/~gohlke/pythonlibs/>`__
 
 


### PR DESCRIPTION
The default wheels for cibuildwheel are 2014, and that seems reasonable. This documents the change.
