### PR TITLE
BUG: Warn when CRS cannot be converted to PROJ or PROJ JSON

### DIFF
--- a/docs/history.rst
+++ b/docs/history.rst
@@ -9,7 +9,7 @@ Latest
 - BUG: remove CustomConstructorCRS @abstractmethod decorator (pull #1018)
 - BUG: Correct type annotation for AreaofUse.bounds (issue #1012)
 - BUG: :func:`pyproj.datadir.get_data_dir` support for conda Windows (issue #1029)
-- ENH: warn when :meth:`pyproj.crs.CRS.to_wkt()` returns None (issue #1036)
+- ENH: warn when :meth:`pyproj.crs.CRS.to_wkt()`, :meth:`pyproj.crs.CRS.to_proj4()`, or :meth:`pyproj.crs.CRS.to_json()` returns None (issue #1036)
 - ENH: Added support for int-like strings and numpy dtypes (issues #1026 and #1835)
 
 3.3.0

--- a/pyproj/crs/crs.py
+++ b/pyproj/crs/crs.py
@@ -1238,7 +1238,15 @@ class CRS:
         -------
         str
         """
-        return self._crs.to_json(pretty=pretty, indentation=indentation)
+        proj_json = self._crs.to_json(pretty=pretty, indentation=indentation)
+        if proj_json is None:
+            warnings.warn(
+                "CRS cannot be converted to a PROJ JSON string. "
+                "Future versions of pyproj will raise a CRSError in this case.",
+                FutureWarning,
+                stacklevel=2,
+            )
+        return proj_json
 
     def to_json_dict(self) -> dict:
         """
@@ -1271,7 +1279,15 @@ class CRS:
         -------
         str
         """
-        return self._crs.to_proj4(version=version)
+        proj = self._crs.to_proj4(version=version)
+        if proj is None:
+            warnings.warn(
+                "CRS cannot be converted to a PROJ string. "
+                "Future versions of pyproj will raise a CRSError in this case.",
+                FutureWarning,
+                stacklevel=2,
+            )
+        return proj
 
     def to_epsg(self, min_confidence: int = 70) -> Optional[int]:
         """

--- a/test/crs/test_crs.py
+++ b/test/crs/test_crs.py
@@ -1,6 +1,7 @@
 import concurrent.futures
 import json
 import platform
+from unittest.mock import patch
 
 import numpy
 import pytest
@@ -945,6 +946,24 @@ def test_to_wkt_none_warning(wkt_version):
     crs = CRS.from_wkt(wkt_string)
     with pytest.warns(FutureWarning, match="CRS cannot be converted to a WKT string"):
         assert crs.to_wkt(version=wkt_version) is None
+
+
+def test_to_proj4_none_warning():
+    crs = CRS("EPSG:4326")
+    with patch("pyproj.crs.crs.CRS._crs") as crs_mock, pytest.warns(
+        FutureWarning, match="CRS cannot be converted to a PROJ string"
+    ):
+        crs_mock.to_proj4.return_value = None
+        assert crs.to_proj4() is None
+
+
+def test_to_json_none_warning():
+    crs = CRS("EPSG:4326")
+    with patch("pyproj.crs.crs.CRS._crs") as crs_mock, pytest.warns(
+        FutureWarning, match="CRS cannot be converted to a PROJ JSON string"
+    ):
+        crs_mock.to_json.return_value = None
+        assert crs.to_json() is None
 
 
 def test_to_proj4_enum():


### PR DESCRIPTION
Related to #1036

I wasn't able to find a real life scenario when this occurs. At this point it is purely theoretical. But, good to have a warning (and later an error) in case someone runs into it.