### PR TITLE
CLN: Remove deprecated 'skip_equivalent' kwarg from transformers and 'errcheck' kwarg from CRS.from_cf

### DIFF
--- a/docs/history.rst
+++ b/docs/history.rst
@@ -6,6 +6,7 @@ Latest
 - DEP: Minimum PROJ version 8.1 (issue #1011)
 - BUG: Fix transformer list for 3D transformations in :class:`pyproj.transformer.TransformerGroup` (discussion #1072)
 - ENH: Added authority, accuracy, and allow_ballpark kwargs to :class:`pyproj.transformer.TransformerGroup` (pull #1076)
+- CLN: Remove deprecated `skip_equivalent` kwarg from transformers and `errcheck` kwarg from :meth:`pyproj.crs.CRS.from_cf` (pull #1077)
 
 3.3.1
 -------

--- a/pyproj/crs/crs.py
+++ b/pyproj/crs/crs.py
@@ -728,14 +728,11 @@ class CRS:
         ellipsoidal_cs: Any = None,
         cartesian_cs: Any = None,
         vertical_cs: Any = None,
-        errcheck=False,
     ) -> "CRS":
         """
         .. versionadded:: 2.2.0
 
         .. versionadded:: 3.0.0 ellipsoidal_cs, cartesian_cs, vertical_cs
-
-        .. deprecated:: 3.2.0 errcheck
 
         This converts a Climate and Forecast (CF) Grid Mapping Version 1.8
         dict to a :obj:`pyproj.crs.CRS` object.
@@ -758,21 +755,12 @@ class CRS:
             Input to create a Vertical Coordinate System accepted by
             :meth:`pyproj.crs.CoordinateSystem.from_user_input`
             or :class:`pyproj.crs.coordinate_system.VerticalCS`
-        errcheck: bool, default=False
-            This parameter is for backwards compatibility with the old version.
-            It currently does nothing when True or False. DEPRECATED.
 
         Returns
         -------
         CRS
         """
         # pylint: disable=too-many-branches
-        if errcheck:
-            warnings.warn(
-                "errcheck is deprecated as it does nothing.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
 
         unknown_names = ("unknown", "undefined")
         if "crs_wkt" in in_cf:

--- a/pyproj/transformer.py
+++ b/pyproj/transformer.py
@@ -147,7 +147,6 @@ class TransformerGroup(_TransformerGroup):
         self,
         crs_from: Any,
         crs_to: Any,
-        skip_equivalent: bool = False,
         always_xy: bool = False,
         area_of_interest: Optional[AreaOfInterest] = None,
         authority: Optional[str] = None,
@@ -159,17 +158,12 @@ class TransformerGroup(_TransformerGroup):
 
         .. versionadded:: 3.4.0 authority, accuracy, allow_ballpark
 
-        .. deprecated:: 3.1 skip_equivalent
-
         Parameters
         ----------
         crs_from: pyproj.crs.CRS or input used to create one
             Projection of input data.
         crs_to: pyproj.crs.CRS or input used to create one
             Projection of output data.
-        skip_equivalent: bool, default=False
-            DEPRECATED: If true, will skip the transformation operation
-            if input and output projections are equivalent.
         always_xy: bool, default=False
             If true, the transform method will accept as input and return as output
             coordinates using the traditional GIS order, that is longitude, latitude
@@ -194,13 +188,6 @@ class TransformerGroup(_TransformerGroup):
             in the candidate coordinate operations. Default is to allow.
 
         """
-        if skip_equivalent:
-            warnings.warn(
-                "skip_equivalent is deprecated.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-
         super().__init__(
             CRS.from_user_input(crs_from)._crs,
             CRS.from_user_input(crs_to)._crs,
@@ -483,16 +470,13 @@ class Transformer:
     def from_proj(
         proj_from: Any,
         proj_to: Any,
-        skip_equivalent: bool = False,
         always_xy: bool = False,
         area_of_interest: Optional[AreaOfInterest] = None,
     ) -> "Transformer":
         """Make a Transformer from a :obj:`pyproj.Proj` or input used to create one.
 
-        .. versionadded:: 2.1.2 skip_equivalent
         .. versionadded:: 2.2.0 always_xy
         .. versionadded:: 2.3.0 area_of_interest
-        .. deprecated:: 3.1 skip_equivalent
 
         Parameters
         ----------
@@ -500,9 +484,6 @@ class Transformer:
             Projection of input data.
         proj_to: :obj:`pyproj.Proj` or input used to create one
             Projection of output data.
-        skip_equivalent: bool, default=False
-            DEPRECATED: If true, will skip the transformation operation
-            if input and output projections are equivalent.
         always_xy: bool, default=False
             If true, the transform method will accept as input and return as output
             coordinates using the traditional GIS order, that is longitude, latitude
@@ -526,7 +507,6 @@ class Transformer:
         return Transformer.from_crs(
             proj_from.crs,
             proj_to.crs,
-            skip_equivalent=skip_equivalent,
             always_xy=always_xy,
             area_of_interest=area_of_interest,
         )
@@ -535,7 +515,6 @@ class Transformer:
     def from_crs(
         crs_from: Any,
         crs_to: Any,
-        skip_equivalent: bool = False,
         always_xy: bool = False,
         area_of_interest: Optional[AreaOfInterest] = None,
         authority: Optional[str] = None,
@@ -544,11 +523,9 @@ class Transformer:
     ) -> "Transformer":
         """Make a Transformer from a :obj:`pyproj.crs.CRS` or input used to create one.
 
-        .. versionadded:: 2.1.2 skip_equivalent
         .. versionadded:: 2.2.0 always_xy
         .. versionadded:: 2.3.0 area_of_interest
         .. versionadded:: 3.1.0 authority, accuracy, allow_ballpark
-        .. deprecated:: 3.1 skip_equivalent
 
         Parameters
         ----------
@@ -556,9 +533,6 @@ class Transformer:
             Projection of input data.
         crs_to: pyproj.crs.CRS or input used to create one
             Projection of output data.
-        skip_equivalent: bool, default=False
-            DEPRECATED: If true, will skip the transformation operation
-            if input and output projections are equivalent.
         always_xy: bool, default=False
             If true, the transform method will accept as input and return as output
             coordinates using the traditional GIS order, that is longitude, latitude
@@ -586,13 +560,6 @@ class Transformer:
         Transformer
 
         """
-        if skip_equivalent:
-            warnings.warn(
-                "skip_equivalent is deprecated.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-
         return Transformer(
             TransformerFromCRS(
                 cstrencode(CRS.from_user_input(crs_from).srs),
@@ -1135,13 +1102,10 @@ def transform(  # pylint: disable=invalid-name
     tt: Any = None,
     radians: bool = False,
     errcheck: bool = False,
-    skip_equivalent: bool = False,
     always_xy: bool = False,
 ):
     """
-    .. versionadded:: 2.1.2 skip_equivalent
     .. versionadded:: 2.2.0 always_xy
-    .. deprecated::3.1 skip_equivalent
 
     .. deprecated:: 2.6.1
         This function is deprecated. See: :ref:`upgrade_transformer`
@@ -1222,9 +1186,9 @@ def transform(  # pylint: disable=invalid-name
         DeprecationWarning,
         stacklevel=2,
     )
-    return Transformer.from_proj(
-        p1, p2, skip_equivalent=skip_equivalent, always_xy=always_xy
-    ).transform(xx=x, yy=y, zz=z, tt=tt, radians=radians, errcheck=errcheck)
+    return Transformer.from_proj(p1, p2, always_xy=always_xy).transform(
+        xx=x, yy=y, zz=z, tt=tt, radians=radians, errcheck=errcheck
+    )
 
 
 def itransform(  # pylint: disable=invalid-name
@@ -1235,13 +1199,10 @@ def itransform(  # pylint: disable=invalid-name
     time_3rd: bool = False,
     radians: bool = False,
     errcheck: bool = False,
-    skip_equivalent: bool = False,
     always_xy: bool = False,
 ):
     """
-    .. versionadded:: 2.1.2 skip_equivalent
     .. versionadded:: 2.2.0 always_xy
-    .. deprecated::3.1 skip_equivalent
 
     .. deprecated:: 2.6.1
         This function is deprecated. See: :ref:`upgrade_transformer`
@@ -1306,8 +1267,6 @@ def itransform(  # pylint: disable=invalid-name
         DeprecationWarning,
         stacklevel=2,
     )
-    return Transformer.from_proj(
-        p1, p2, skip_equivalent=skip_equivalent, always_xy=always_xy
-    ).itransform(
+    return Transformer.from_proj(p1, p2, always_xy=always_xy).itransform(
         points, switch=switch, time_3rd=time_3rd, radians=radians, errcheck=errcheck
     )

--- a/test/crs/test_crs_cf.py
+++ b/test/crs/test_crs_cf.py
@@ -748,15 +748,13 @@ def test_geos_crs_sweep():
 
 
 def test_geos_crs_fixed_angle_axis():
-    with pytest.warns(DeprecationWarning):
-        crs = CRS.from_cf(
-            dict(
-                grid_mapping_name="geostationary",
-                perspective_point_height=1,
-                fixed_angle_axis="y",
-            ),
-            errcheck=True,
-        )
+    crs = CRS.from_cf(
+        dict(
+            grid_mapping_name="geostationary",
+            perspective_point_height=1,
+            fixed_angle_axis="y",
+        ),
+    )
     expected_cf = {
         "semi_major_axis": 6378137.0,
         "semi_minor_axis": crs.ellipsoid.semi_minor_metre,

--- a/test/test_transform.py
+++ b/test/test_transform.py
@@ -49,9 +49,3 @@ def test_transform():
     assert_allclose(numpy.maximum.reduce(numpy.ravel(x3 - x1)), 0, atol=1e-4)
     assert_allclose(numpy.minimum.reduce(numpy.ravel(y3 - y1)), 0, atol=1e-4)
     assert_allclose(numpy.maximum.reduce(numpy.ravel(y3 - y1)), 0, atol=1e-4)
-
-
-def test_skip_equivalent():
-    with pytest.warns(DeprecationWarning):
-        xeq, yeq = transform(4326, 4326, 30, 60, skip_equivalent=True)
-    assert (xeq, yeq) == (30, 60)

--- a/test/test_transformer.py
+++ b/test/test_transformer.py
@@ -79,23 +79,6 @@ def test_lambert_conformal_transform():
     assert_almost_equal((Long1, Lat1, H1), (-4.6753456, 32.902199, 1341.467), decimal=5)
 
 
-def test_equivalent_crs():
-    with pytest.warns(DeprecationWarning):
-        Transformer.from_crs("epsg:4326", 4326, skip_equivalent=True)
-
-
-def test_equivalent_proj():
-    with pytest.warns(FutureWarning):
-        proj_from = pyproj.Proj("+init=epsg:4326")
-    with pytest.warns(DeprecationWarning):
-        Transformer.from_proj(proj_from, 4326, skip_equivalent=True)
-
-
-def test_equivalent_transformer_group():
-    with pytest.warns(DeprecationWarning):
-        TransformerGroup("epsg:4326", 4326, skip_equivalent=True)
-
-
 def test_4d_transform():
     transformer = Transformer.from_pipeline("+init=ITRF2008:ITRF2000")
     assert_almost_equal(


### PR DESCRIPTION
 - [x] Tests updated
 - [x] Fully documented, including `history.rst` for all changes and `api/*.rst` for new API
