### PR TITLE
TST: handle empty full_name in test_coordinate_operation_grids__alternative_grid_name with PROJ 9.1+

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -12,6 +12,7 @@ _NETWORK_ENABLED = pyproj.network.is_network_enabled()
 PROJ_LOOSE_VERSION = version.parse(pyproj.__proj_version__)
 PROJ_GTE_82 = PROJ_LOOSE_VERSION >= version.parse("8.2")
 PROJ_GTE_901 = PROJ_LOOSE_VERSION >= version.parse("9.0.1")
+PROJ_GTE_91 = PROJ_LOOSE_VERSION >= version.parse("9.1")
 RGF93toWSG84 = "RGF93 v1 to WGS 84 (1)" if PROJ_GTE_82 else "RGF93 to WGS 84 (1)"
 
 

--- a/test/crs/test_crs.py
+++ b/test/crs/test_crs.py
@@ -22,6 +22,7 @@ from pyproj.exceptions import CRSError
 from pyproj.transformer import TransformerGroup
 from test.conftest import (
     PROJ_GTE_82,
+    PROJ_GTE_91,
     PROJ_GTE_901,
     RGF93toWSG84,
     assert_can_pickle,
@@ -612,7 +613,10 @@ def test_coordinate_operation_grids__alternative_grid_name():
     assert grid.short_name == "ca_nrc_ntv1_can.tif"
     if grids_available(grid.short_name):
         assert grid.available is True
-        assert grid.full_name.endswith(grid.short_name)
+        if PROJ_GTE_91:
+            assert grid.full_name == ""
+        else:
+            assert grid.full_name.endswith(grid.short_name)
     else:
         assert grid.available is False
         assert grid.full_name == ""


### PR DESCRIPTION
 - [x] Closes #1078
 