### PR TITLE
CI: Remove latest PROJ docker build test

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -42,8 +42,6 @@ jobs:
             proj-version: '8.1.1'
           - python-version: '3.9'
             proj-version: '8.2.1'
-          - python-version: '3.10'
-            proj-version: 'latest'
     steps:
       - uses: actions/checkout@v2
 


### PR DESCRIPTION
Related to: https://github.com/OSGeo/PROJ/issues/3192

Tests fail because the next release version of PROJ is not updated until the release.