### PR TITLE
REF: use regex to process PROJ strings in CRS.to_dict()

### DIFF
--- a/docs/history.rst
+++ b/docs/history.rst
@@ -7,6 +7,7 @@ Latest
 - BUG: Fix transformer list for 3D transformations in :class:`pyproj.transformer.TransformerGroup` (discussion #1072)
 - ENH: Added authority, accuracy, and allow_ballpark kwargs to :class:`pyproj.transformer.TransformerGroup` (pull #1076)
 - CLN: Remove deprecated `skip_equivalent` kwarg from transformers and `errcheck` kwarg from :meth:`pyproj.crs.CRS.from_cf` (pull #1077)
+- REF: use regex to process PROJ strings in :meth:`pyproj.crs.CRS.to_dict()`(pull #1086)
 
 3.3.1
 -------


### PR DESCRIPTION
`pyproj/crs/crs.py:595:17: C417 Unnecessary use of map - use a generator expression instead.`
 Related: https://github.com/adamchainz/flake8-comprehensions/pull/409

Based on: https://github.com/rasterio/rasterio/pull/2352 (thanks @groutr :+1:)