### PR TITLE
BUG: Mercator A defined only for lat_0 = 0

### DIFF
--- a/docs/history.rst
+++ b/docs/history.rst
@@ -8,6 +8,7 @@ Latest
 - ENH: Added authority, accuracy, and allow_ballpark kwargs to :class:`pyproj.transformer.TransformerGroup` (pull #1076)
 - CLN: Remove deprecated `skip_equivalent` kwarg from transformers and `errcheck` kwarg from :meth:`pyproj.crs.CRS.from_cf` (pull #1077)
 - REF: use regex to process PROJ strings in :meth:`pyproj.crs.CRS.to_dict()`(pull #1086)
+- BUG: :class:`pyproj.crs.coordinate_operation.MercatorAConversion` defined only for lat_0 = 0 (issue #1089)
 
 3.3.1
 -------

--- a/pyproj/crs/coordinate_operation.py
+++ b/pyproj/crs/coordinate_operation.py
@@ -687,8 +687,10 @@ class MercatorAConversion(CoordinateOperation):
         """
         Parameters
         ----------
-        longitude_natural_origin: float, default=0.0
-            Latitude of natural origin (lat_0).
+        latitude_natural_origin: float, default=0.0
+            Latitude of natural origin (lat_0). Must be 0 by `this conversion's
+            definition
+            <https://epsg.org/coord-operation-method_9804/Mercator-variant-A.html>`_.
         longitude_natural_origin: float, default=0.0
             Longitude of natural origin (lon_0).
         false_easting: float, default=0.0
@@ -699,6 +701,10 @@ class MercatorAConversion(CoordinateOperation):
             Scale factor at natural origin (k or k_0).
 
         """
+        if latitude_natural_origin != 0:
+            raise CRSError(
+                "This conversion is defined for only latitude_natural_origin = 0."
+            )
         merc_json = {
             "$schema": "https://proj.org/schemas/v0.2/projjson.schema.json",
             "type": "Conversion",

--- a/test/crs/test_crs_cf.py
+++ b/test/crs/test_crs_cf.py
@@ -1265,7 +1265,7 @@ def test_lambert_cylindrical_equal_area():
 
 
 def test_mercator_a():
-    crs = ProjectedCRS(conversion=MercatorAConversion(1, 2, 3, 4))
+    crs = ProjectedCRS(conversion=MercatorAConversion(0, 2, 3, 4))
     expected_cf = {
         "semi_major_axis": 6378137.0,
         "semi_minor_axis": crs.ellipsoid.semi_minor_metre,
@@ -1275,7 +1275,7 @@ def test_mercator_a():
         "prime_meridian_name": "Greenwich",
         "horizontal_datum_name": "World Geodetic System 1984",
         "grid_mapping_name": "mercator",
-        "standard_parallel": 1.0,
+        "standard_parallel": 0.0,
         "longitude_of_projection_origin": 2.0,
         "false_easting": 3.0,
         "false_northing": 4.0,

--- a/test/crs/test_crs_coordinate_operation.py
+++ b/test/crs/test_crs_coordinate_operation.py
@@ -314,7 +314,7 @@ def test_mercator_a_operation__defaults():
 
 def test_mercator_a_operation():
     aeaop = MercatorAConversion(
-        latitude_natural_origin=1,
+        latitude_natural_origin=0,
         longitude_natural_origin=2,
         false_easting=3,
         false_northing=4,
@@ -323,12 +323,17 @@ def test_mercator_a_operation():
     assert aeaop.name == "unknown"
     assert aeaop.method_name == "Mercator (variant A)"
     assert _to_dict(aeaop) == {
-        "Latitude of natural origin": 1.0,
+        "Latitude of natural origin": 0.0,
         "Longitude of natural origin": 2.0,
         "False easting": 3.0,
         "False northing": 4.0,
         "Scale factor at natural origin": 0.5,
     }
+
+
+def test_mercator_a_operation__invalid_lat0():
+    with pytest.raises(CRSError):
+        MercatorAConversion(latitude_natural_origin=1)
 
 
 def test_mercator_b_operation__defaults():


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

Raises `CRSError` if latitude_natural_origin != 0.

 - [X] Closes #1089 
 - [X] Tests added
 - [X] Fully documented, including `history.rst` for all changes and `api/*.rst` for new API
