### PR TITLE
BUG: Ensure numpy masked arrays stay masked after projection

### DIFF
--- a/docs/history.rst
+++ b/docs/history.rst
@@ -10,6 +10,7 @@ Latest
 - REF: use regex to process PROJ strings in :meth:`.CRS.to_dict` (pull #1086)
 - BUG: :class:`.MercatorAConversion` defined only for lat_0 = 0 (issue #1089)
 - BUG: Add support for `PROJ_DATA` environment variable (issue #1097)
+- BUG: Ensure numpy masked arrays stay masked after projection (issue #1102)
 
 3.3.1
 -------

--- a/pyproj/utils.py
+++ b/pyproj/utils.py
@@ -109,7 +109,14 @@ def _copytobuffer(xxx: Any, inplace: bool = False) -> Tuple[Any, DataType]:
         The copy of the data prepared for the PROJ API & Python Buffer API.
     """
     # check for pandas.Series, xarray.DataArray or dask.array.Array
-    if hasattr(xxx, "__array__") and callable(xxx.__array__):
+    # also handle numpy masked Arrays; note that pandas.Series also has a
+    # "mask" attribute, hence checking for simply the "mask" attr in that
+    # case isn't sufficient
+    if (
+        not hasattr(xxx, "hardmask")
+        and hasattr(xxx, "__array__")
+        and callable(xxx.__array__)
+    ):
         xxx = xxx.__array__()
 
     # handle numpy data

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -42,6 +42,13 @@ def test__copytobuffer__numpy_array(in_arr):
     )
 
 
+def test__copytobuffer__numpy_masked_array():
+    in_arr = numpy.ma.array([1])
+    out_arr, dtype = _copytobuffer(in_arr)
+
+    assert isinstance(out_arr, numpy.ma.MaskedArray)
+
+
 def test__copytobuffer__fortran_order():
     data = numpy.ones((2, 4), dtype=numpy.float64, order="F")
     converted_data, dtype = _copytobuffer(data)


### PR DESCRIPTION
As noted in #1102, projecting numpy masked arrays returned numpy masked
arrays in the 2.x series of pyproj.  This behaviour changed in commit
4ab3ff7 as part of the 3.x series, where a "plain" numpy ndarray was returned.  The change
implemented here ensures that projecting numpy masked arrays returns
masked arrays as was previously the case.

I'm fairly sure that the fix I've implemented here does actually fix the issue mentioned in #1102; nevertheless, please review my changes carefully as I'm not very familiar with this codebase.

 - [x] Closes #1102 
 - [x] Tests added
 - [x] Fully documented, including `history.rst` for all changes and `api/*.rst` for new API
