### PR TITLE
BLD: Don't specify runtime_library_dirs on Cygwin

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -167,7 +167,7 @@ def get_extension_modules():
     ext_options = {
         "include_dirs": include_dirs,
         "library_dirs": library_dirs,
-        "runtime_library_dirs": library_dirs if os.name != "nt" else None,
+        "runtime_library_dirs": library_dirs if os.name != "nt" and sys.platform != "cygwin" else None,
         "libraries": get_libraries(library_dirs),
     }
     # setup cythonized modules

--- a/setup.py
+++ b/setup.py
@@ -167,7 +167,9 @@ def get_extension_modules():
     ext_options = {
         "include_dirs": include_dirs,
         "library_dirs": library_dirs,
-        "runtime_library_dirs": library_dirs if os.name != "nt" and sys.platform != "cygwin" else None,
+        "runtime_library_dirs": (
+            library_dirs if os.name != "nt" and sys.platform != "cygwin" else None
+        ),
         "libraries": get_libraries(library_dirs),
     }
     # setup cythonized modules


### PR DESCRIPTION
runtime_library_dirs isn't supported by PE/COFF, used by Windows and Cygwin; it seems to be an ELF thing.

<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [X] Closes #1113, pypa/distutils#171
 - [ ] Tests added
 - [ ] Fully documented, including `history.rst` for all changes and `api/*.rst` for new API
