### PR TITLE
TST: test_coordinate_operation_grids__alternative_grid_name - handle when PROJ 9.1 and local grid exists

### DIFF
--- a/test/crs/test_crs.py
+++ b/test/crs/test_crs.py
@@ -604,12 +604,14 @@ def test_coordinate_operation_grids__alternative_grid_name():
     assert grid.direct_download is True
     assert grid.open_license is True
     assert grid.short_name == "ca_nrc_ntv1_can.tif"
-    if PROJ_GTE_91 and pyproj.network.is_network_enabled():
-        assert grid.available is True
-        assert grid.full_name == ""
-    elif grids_available(grid.short_name):
+    if (PROJ_GTE_91 and grids_available(grid.short_name, check_network=False)) or (
+        not PROJ_GTE_91 and grids_available(grid.short_name)
+    ):
         assert grid.available is True
         assert grid.full_name.endswith(grid.short_name)
+    elif PROJ_GTE_91 and pyproj.network.is_network_enabled():
+        assert grid.available is True
+        assert grid.full_name == ""
     else:
         assert grid.available is False
         assert grid.full_name == ""


### PR DESCRIPTION
Related: #1080 #1090


https://github.com/pyproj4/pyproj/runs/8198324186
```
    @pytest.mark.grid
    def test_coordinate_operation_grids__alternative_grid_name():
...
        if PROJ_GTE_91 and pyproj.network.is_network_enabled():
            assert grid.available is True
>           assert grid.full_name == ""
E           AssertionError: assert '/home/runner..._ntv1_can.tif' == ''
E             + /home/runner/.local/share/proj/ca_nrc_nt
```