### PR TITLE
REF: Use importlib.metadata.version in show_versions for python deps

### DIFF
--- a/pyproj/_show_versions.py
+++ b/pyproj/_show_versions.py
@@ -4,7 +4,7 @@ Utility methods to print system info for debugging
 adapted from :func:`sklearn.utils._show_versions`
 which was adapted from :func:`pandas.show_versions`
 """
-import importlib
+import importlib.metadata
 import platform
 import sys
 
@@ -85,24 +85,11 @@ def _get_deps_info():
 
     def get_version(module):
         try:
-            return module.__version__
-        except AttributeError:
-            return module.version
+            return importlib.metadata.version(module)
+        except importlib.metadata.PackageNotFoundError:
+            return None
 
-    deps_info = {}
-
-    for modname in deps:
-        try:
-            if modname in sys.modules:
-                mod = sys.modules[modname]
-            else:
-                mod = importlib.import_module(modname)
-            ver = get_version(mod)
-            deps_info[modname] = ver
-        except ImportError:
-            deps_info[modname] = None
-
-    return deps_info
+    return {dep: get_version(dep) for dep in deps}
 
 
 def _print_info_dict(info_dict):


### PR DESCRIPTION
This should simplify the logic and be more robust.