### PR TITLE
Fix/20221203/fixed dist info requirement for deploy

### DIFF
--- a/docs/history.rst
+++ b/docs/history.rst
@@ -4,6 +4,10 @@ Change Log
 Latest
 -------
 
+3.4.1
+-----
+- BUG: Changed so that the setup.cfg depends on the version code in the __init__.py instead of the other way around (issuue #1155)
+
 3.4.0
 -----
 - WHL: Python 3.11 Wheels (issue #1110)

--- a/pyproj/__init__.py
+++ b/pyproj/__init__.py
@@ -28,7 +28,6 @@ HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTIO
 OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
-import importlib.metadata
 import warnings
 
 import pyproj.network
@@ -67,7 +66,7 @@ from pyproj.transformer import (  # noqa: F401 pylint: disable=unused-import
     transform,
 )
 
-__version__ = importlib.metadata.version(__package__)
+__version__ = "3.4.2.dev0"
 __all__ = [
     "Proj",
     "Geod",

--- a/pyproj/__init__.py
+++ b/pyproj/__init__.py
@@ -66,7 +66,7 @@ from pyproj.transformer import (  # noqa: F401 pylint: disable=unused-import
     transform,
 )
 
-__version__ = "3.4.2.dev0"
+__version__ = "3.4.1.dev1"
 __all__ = [
     "Proj",
     "Geod",

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = pyproj
-version = 3.4.1.dev0
+version = attr: pyproj.__version__
 description = Python interface to PROJ (cartographic projections and coordinate transformations library)
 long_description = file: README.md
 long_description_content_type = text/markdown


### PR DESCRIPTION
Removes dependency of dist-info folder inside the `__init__.py` file, fixing break when running the package in "slim" environment due to the lack of the METADATA file.

 - [x] Closes #1155
 - [X] Fully documented, including `history.rst` for all changes
