### PR TITLE
REF: Use upper case EPSG code when creating CRS

### DIFF
--- a/docs/advanced_examples.rst
+++ b/docs/advanced_examples.rst
@@ -63,7 +63,7 @@ transformations as well as missing transformations.
 .. code-block:: python
 
     >>> from pyproj.transformer import TransformerGroup
-    >>> trans_group = TransformerGroup("epsg:4326","epsg:2964")
+    >>> trans_group = TransformerGroup("EPSG:4326","EPSG:2964")
     >>> trans_group
     <TransformerGroup: best_available=True>
     - transformers: 8
@@ -85,7 +85,7 @@ transformations as well as missing transformations.
 .. code-block:: python
 
     >>> from pyproj.transformer import TransformerGroup
-    >>> tg = TransformerGroup("epsg:4326", "+proj=aea +lat_0=50 +lon_0=-154 +lat_1=55 +lat_2=65 +x_0=0 +y_0=0 +datum=NAD27 +no_defs +type=crs +units=m", always_xy=True)
+    >>> tg = TransformerGroup("EPSG:4326", "+proj=aea +lat_0=50 +lon_0=-154 +lat_1=55 +lat_2=65 +x_0=0 +y_0=0 +datum=NAD27 +no_defs +type=crs +units=m", always_xy=True)
     UserWarning: Best transformation is not available due to missing Grid(short_name=ntv2_0.gsb, full_name=, package_name=proj-datumgrid-north-america, url=https://download.osgeo.org/proj/proj-datumgrid-north-america-latest.zip, direct_download=True, open_license=True, available=False)
     f"{operation.grids[0]!r}"
     >>> tg
@@ -111,7 +111,7 @@ which transformation operation is selected in the transformation.
 .. code-block:: python
 
     >>> from pyproj.transformer import Transformer, AreaOfInterest
-    >>> transformer = Transformer.from_crs("epsg:4326", "epsg:2694")
+    >>> transformer = Transformer.from_crs("EPSG:4326", "EPSG:2694")
     >>> transformer
     <Concatenated Operation Transformer: pipeline>
     Description: Inverse of Pulkovo 1995 to WGS 84 (2) + 3-degree Gauss-Kruger zone 60
@@ -119,8 +119,8 @@ which transformation operation is selected in the transformation.
     - name: Russia
     - bounds: (18.92, 39.87, -168.97, 85.2)
     >>> transformer = Transformer.from_crs(
-    ...     "epsg:4326",
-    ...     "epsg:2694",
+    ...     "EPSG:4326",
+    ...     "EPSG:2694",
     ...     area_of_interest=AreaOfInterest(-136.46, 49.0, -60.72, 83.17),
     ... )
     >>> transformer

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -24,7 +24,7 @@ Here are some examples of initialization.
 
     >>> from pyproj import CRS
     >>> crs = CRS.from_epsg(4326)
-    >>> crs = CRS.from_string("epsg:4326")
+    >>> crs = CRS.from_string("EPSG:4326")
     >>> crs = CRS.from_proj4("+proj=latlon")
     >>> crs = CRS.from_user_input(4326)
 
@@ -407,7 +407,7 @@ ellipsoid name as well as deriving one using a :class:`pyproj.crs.CRS`.
     >>> geod_clrk = Geod(ellps='clrk66') # Use Clarke 1866 ellipsoid.
     >>> geod_clrk
     Geod(ellps='clrk66')
-    >>> geod_wgs84 = CRS("epsg:4326").get_geod()
+    >>> geod_wgs84 = CRS("EPSG:4326").get_geod()
     >>> geod_wgs84
     Geod('+a=6378137 +f=0.0033528106647475126')
 

--- a/docs/gotchas.rst
+++ b/docs/gotchas.rst
@@ -154,7 +154,7 @@ the `init=` syntax is that the CRS are different.
 
     >>> from pyproj import CRS
     >>> crs_deprecated = CRS(init="epsg:4544")
-    >>> crs = CRS("epsg:4544")
+    >>> crs = CRS("EPSG:4544")
     >>> crs == crs_deprecated
     False
 
@@ -289,5 +289,5 @@ pyproj 1 style:
 pyproj 2 style:
 
     >>> from pyproj import Transformer
-    >>> transformer = Transformer.from_crs("epsg:4326", "epsg:3857")
+    >>> transformer = Transformer.from_crs("EPSG:4326", "EPSG:3857")
     >>> transformer.transform(12, 12)

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -7,6 +7,7 @@ Latest
 3.4.1
 -----
 - BUG: Changed so that the setup.cfg depends on the version code in the __init__.py instead of the other way around (issuue #1155)
+- REF: Use upper case EPSG code when creating CRS (pull #1162)
 
 3.4.0
 -----

--- a/pyproj/_crs.pyx
+++ b/pyproj/_crs.pyx
@@ -2712,7 +2712,7 @@ cdef class _CRS(Base):
         Example:
 
         >>> from pyproj import CRS
-        >>> ccs = CRS("epsg:4328")
+        >>> ccs = CRS("EPSG:4328")
         >>> ccs.to_epsg()
         4328
 
@@ -2757,7 +2757,7 @@ cdef class _CRS(Base):
         Example:
 
         >>> from pyproj import CRS
-        >>> ccs = CRS("epsg:4328")
+        >>> ccs = CRS("EPSG:4328")
         >>> ccs.to_authority()
         ('EPSG', '4328')
 
@@ -2802,7 +2802,7 @@ cdef class _CRS(Base):
         Example:
 
         >>> from pyproj import CRS
-        >>> ccs = CRS("epsg:4328")
+        >>> ccs = CRS("EPSG:4328")
         >>> ccs.list_authority()
         [AuthorityMatchInfo(auth_name='EPSG', code='4326', confidence=100)]
 

--- a/pyproj/crs/crs.py
+++ b/pyproj/crs/crs.py
@@ -147,7 +147,7 @@ def _prepare_from_authority(auth_name: str, auth_code: Union[str, int]):
 
 
 def _prepare_from_epsg(auth_code: Union[str, int]):
-    return _prepare_from_authority("epsg", auth_code)
+    return _prepare_from_authority("EPSG", auth_code)
 
 
 def _is_epsg_code(auth_code: Any) -> bool:
@@ -1301,7 +1301,7 @@ class CRS:
         Example:
 
         >>> from pyproj import CRS
-        >>> ccs = CRS("epsg:4328")
+        >>> ccs = CRS("EPSG:4328")
         >>> ccs.to_epsg()
         4328
 
@@ -1340,7 +1340,7 @@ class CRS:
         Example:
 
         >>> from pyproj import CRS
-        >>> ccs = CRS("epsg:4328")
+        >>> ccs = CRS("EPSG:4328")
         >>> ccs.to_authority()
         ('EPSG', '4328')
 
@@ -1383,7 +1383,7 @@ class CRS:
         Example:
 
         >>> from pyproj import CRS
-        >>> ccs = CRS("epsg:4328")
+        >>> ccs = CRS("EPSG:4328")
         >>> ccs.list_authority()
         [AuthorityMatchInfo(auth_name='EPSG', code='4326', confidence=100)]
 

--- a/pyproj/proj.py
+++ b/pyproj/proj.py
@@ -91,14 +91,14 @@ class Proj(Transformer):
         >>> x,y = p2(-120.108, 34.36116666)
         >>> 'x=%9.3f y=%11.3f' % (x,y)
         'x=765975.641 y=3805993.134'
-        >>> p = Proj("epsg:32667", preserve_units=False)
+        >>> p = Proj("EPSG:32667", preserve_units=False)
         >>> 'x=%12.3f y=%12.3f (meters)' % p(-114.057222, 51.045)
         'x=-1783506.250 y= 6193827.033 (meters)'
-        >>> p = Proj("epsg:32667")
+        >>> p = Proj("EPSG:32667")
         >>> 'x=%12.3f y=%12.3f (feet)' % p(-114.057222, 51.045)
         'x=-5851386.754 y=20320914.191 (feet)'
         >>> # test data with radian inputs
-        >>> p1 = Proj("epsg:4214")
+        >>> p1 = Proj("EPSG:4214")
         >>> x1, y1 = p1(116.366, 39.867)
         >>> f'{x1:.3f} {y1:.3f}'
         '116.366 39.867'
@@ -279,7 +279,7 @@ class Proj(Transformer):
     def definition_string(self) -> str:
         """Returns formal definition string for projection
 
-        >>> Proj("epsg:4326").definition_string()
+        >>> Proj("EPSG:4326").definition_string()
         'proj=longlat datum=WGS84 no_defs ellps=WGS84 towgs84=0,0,0'
         """
         return self.definition

--- a/pyproj/transformer.py
+++ b/pyproj/transformer.py
@@ -748,7 +748,7 @@ class Transformer:
         --------
 
         >>> from pyproj import Transformer
-        >>> transformer = Transformer.from_crs("epsg:4326", "epsg:3857")
+        >>> transformer = Transformer.from_crs("EPSG:4326", "EPSG:3857")
         >>> x3, y3 = transformer.transform(33, 98)
         >>> f"{x3:.3f}  {y3:.3f}"
         '10909310.098  3895303.963'
@@ -781,7 +781,7 @@ class Transformer:
         >>> xpjr, ypjr, zpjr = transprojr.transform(xpj, ypj, zpj, radians=True)
         >>> f"{xpjr:.3f} {ypjr:.3f} {zpjr:.3f}"
         '-2704026.010 -4253051.810 3895878.820'
-        >>> transformer = Transformer.from_proj("epsg:4326", 4326)
+        >>> transformer = Transformer.from_proj("EPSG:4326", 4326)
         >>> xeq, yeq = transformer.transform(33, 98)
         >>> f"{xeq:.0f}  {yeq:.0f}"
         '33  98'


### PR DESCRIPTION
The EPSG database uses the uppercase version. This is for consistency with `to_authority`.