### PR TITLE
BUG: Fix CRS.to_cf for Pole rotation GRIB convention

### DIFF
--- a/docs/history.rst
+++ b/docs/history.rst
@@ -7,6 +7,7 @@ Latest
 3.4.1
 -----
 - BUG: Changed so that the setup.cfg depends on the version code in the __init__.py instead of the other way around (issuue #1155)
+- BUG: Fix :meth:`.CRS.to_cf` for Pole rotation GRIB convention (pull #1167)
 - REF: Use upper case EPSG code when creating CRS (pull #1162)
 
 3.4.0

--- a/pyproj/crs/crs.py
+++ b/pyproj/crs/crs.py
@@ -642,7 +642,7 @@ class CRS:
             CF-1.8 version of the projection.
 
         """
-        # pylint: disable=too-many-branches
+        # pylint: disable=too-many-branches,too-many-return-statements
         cf_dict: Dict[str, Any] = {"crs_wkt": self.to_wkt(wkt_version)}
 
         # handle bound CRS
@@ -696,6 +696,16 @@ class CRS:
 
         if self.is_geographic:
             if self.coordinate_operation:
+                if (
+                    self.coordinate_operation.method_name.lower()
+                    not in _INVERSE_GEOGRAPHIC_GRID_MAPPING_NAME_MAP
+                ):
+                    if errcheck:
+                        warnings.warn(
+                            "Unsupported coordinate operation: "
+                            f"{self.coordinate_operation.method_name}"
+                        )
+                    return {"crs_wkt": cf_dict["crs_wkt"]}
                 cf_dict.update(
                     _INVERSE_GEOGRAPHIC_GRID_MAPPING_NAME_MAP[
                         self.coordinate_operation.method_name.lower()
@@ -729,7 +739,7 @@ class CRS:
                 else:
                     warnings.warn("Coordinate operation not found.")
 
-            return {"crs_wkt": self.to_wkt(wkt_version)}
+            return {"crs_wkt": cf_dict["crs_wkt"]}
 
         cf_dict.update(
             _INVERSE_GRID_MAPPING_NAME_MAP[coordinate_operation_name](

--- a/test/crs/test_crs_cf.py
+++ b/test/crs/test_crs_cf.py
@@ -479,6 +479,43 @@ def test_rotated_pole_to_cf():
     _test_roundtrip(expected_cf, "GEOGCRS[")
 
 
+def test_grib_rotated_pole_to_cf():
+    rotated_pole_wkt = """GEOGCRS["Coordinate System imported from GRIB file",
+        BASEGEOGCRS["Coordinate System imported from GRIB file",
+            DATUM["unnamed",
+                ELLIPSOID["Sphere",6371229,0,
+                    LENGTHUNIT["metre",1,
+                        ID["EPSG",9001]]]],
+            PRIMEM["Greenwich",0,
+                ANGLEUNIT["degree",0.0174532925199433,
+                    ID["EPSG",9122]]]],
+        DERIVINGCONVERSION["Pole rotation (GRIB convention)",
+            METHOD["Pole rotation (GRIB convention)"],
+            PARAMETER["Latitude of the southern pole (GRIB convention)",-33.443381,
+                ANGLEUNIT["degree",0.0174532925199433,
+                    ID["EPSG",9122]]],
+            PARAMETER["Longitude of the southern pole (GRIB convention)",-93.536426,
+                ANGLEUNIT["degree",0.0174532925199433,
+                    ID["EPSG",9122]]],
+            PARAMETER["Axis rotation (GRIB convention)",0,
+                ANGLEUNIT["degree",0.0174532925199433,
+                    ID["EPSG",9122]]]],
+        CS[ellipsoidal,2],
+            AXIS["latitude",north,
+                ORDER[1],
+                ANGLEUNIT["degree",0.0174532925199433,
+                    ID["EPSG",9122]]],
+            AXIS["longitude",east,
+                ORDER[2],
+                ANGLEUNIT["degree",0.0174532925199433,
+                    ID["EPSG",9122]]]]"""
+    crs = CRS(rotated_pole_wkt)
+    with pytest.warns(UserWarning):
+        cf_dict = crs.to_cf(errcheck=True)
+    assert cf_dict.pop("crs_wkt").startswith("GEOGCRS[")
+    assert not cf_dict
+
+
 def test_cf_lambert_conformal_conic_1sp():
     crs = CRS.from_cf(
         dict(


### PR DESCRIPTION
Related: https://github.com/corteva/rioxarray/discussions/591