### PR TITLE
WHL: Add win32 to build_wheels matrix

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -75,6 +75,11 @@ jobs:
           triplet: "x64-windows"
           vcpkg_cache: "c:\\vcpkg\\installed"
           vcpkg_logs: "c:\\vcpkg\\buildtrees\\**\\*.log"
+        - os: "windows-2019"
+          arch: "auto32"
+          triplet: "x86-windows"
+          vcpkg_cache: "c:\\vcpkg\\installed"
+          vcpkg_logs: "c:\\vcpkg\\buildtrees\\**\\*.log"
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
This PR extends the GitHub workflow build matrix to include one more item with variables `{os: "windows-2019": arch: "auto32", triplet: "x86-windows"}`, similarly to the already present win64 build. 

- [X] Closes #1168
- [ ] Tests added
  - No new tests, but I checked that the current tests pass on win32 (as run by cibuildwheel).
- [ ] Fully documented, including `history.rst` for all changes and `api/*.rst` for new API
  - I have not updated `history.rst` because I was not sure if this addition was that relevant (wheels were already there in `pyproj` 3.3.1, so this PR simply brings them back).

