### PR TITLE
BUG: Fix memory leak in CRS.list_authority

### DIFF
--- a/docs/history.rst
+++ b/docs/history.rst
@@ -8,6 +8,7 @@ Latest
 -----
 - BUG: Changed so that the setup.cfg depends on the version code in the __init__.py instead of the other way around (issuue #1155)
 - BUG: Fix :meth:`.CRS.to_cf` for Pole rotation GRIB convention (pull #1167)
+- BUG: Fix :meth:`.CRS.to_authority` memory leak (pull #1178)
 - REF: Use upper case EPSG code when creating CRS (pull #1162)
 
 3.4.0

--- a/pyproj/_crs.pyx
+++ b/pyproj/_crs.pyx
@@ -2883,9 +2883,13 @@ cdef class _CRS(Base):
                             out_confidence_list[iii]
                         )
                     )
+                # at this point, the auth name is copied and we can release the proj object
+                proj_destroy(proj)
+                proj = NULL
         finally:
-            for iii in range(num_proj_objects):
-                proj_destroy(proj_list_get(self.context, proj_list, iii))
+            # If there was an error we have to call proj_destroy
+            # If there was none, calling it on NULL does nothing
+            proj_destroy(proj)
             proj_list_destroy(proj_list)
             CRSError.clear()
         return authority_list


### PR DESCRIPTION
List elements were not properly disposed of when iterating the results of proj_identify. This fixes this and simplifies the cleanup logic.

 - [ ] Tests added (not sure how to test this automatically)
 - [x] Fully documented, including `history.rst` for all changes and `api/*.rst` for new API

You can reproduce this issue with the following snippet (look at the memory usage):

```python
from pyproj import CRS

for i in range(10000):
    CRS.from_epsg(3857).to_epsg()
```
