### PR TITLE
CI: Pin PROJ 9.1.0 for conda tests

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -122,12 +122,12 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: ['3.8', '3.9', '3.10', '3.11']
         python-implementation: [python]
-        proj-version: ['*']
+        proj-version: ['9.1.0']
         include:
           - os: ubuntu-latest
             python-version: '*'
             python-implementation: pypy
-            proj-version: '*'
+            proj-version: '9.1.0'
     steps:
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
Related #1192 

Temporary change. Will revert once latest release is working again.