### PR TITLE
ENH: Add inplace kwarg to Geod.fwd and Geod.inv

### DIFF
--- a/pyproj/geod.py
+++ b/pyproj/geod.py
@@ -240,7 +240,13 @@ class Geod(_Geod):
         )
 
     def fwd(  # pylint: disable=invalid-name
-        self, lons: Any, lats: Any, az: Any, dist: Any, radians: bool = False
+        self,
+        lons: Any,
+        lats: Any,
+        az: Any,
+        dist: Any,
+        radians: bool = False,
+        inplace: bool = False,
     ) -> Tuple[Any, Any, Any]:
         """
         Forward transformation
@@ -248,6 +254,8 @@ class Geod(_Geod):
         Determine longitudes, latitudes and back azimuths of terminus
         points given longitudes and latitudes of initial points,
         plus forward azimuths and distances.
+
+        .. versionadded:: 3.5.0 inplace
 
         Accepted numeric scalar or array:
 
@@ -276,6 +284,10 @@ class Geod(_Geod):
         radians: bool, default=False
             If True, the input data is assumed to be in radians.
             Otherwise, the data is assumed to be in degrees.
+        inplace: bool, default=False
+            If True, will attempt to write the results to the input array
+            instead of returning a new array. This will fail if the input
+            is not an array in C order with the double data type.
 
         Returns
         -------
@@ -287,10 +299,10 @@ class Geod(_Geod):
             Back azimuth(s)
         """
         # process inputs, making copies that support buffer API.
-        inx, x_data_type = _copytobuffer(lons)
-        iny, y_data_type = _copytobuffer(lats)
-        inz, z_data_type = _copytobuffer(az)
-        ind = _copytobuffer(dist)[0]
+        inx, x_data_type = _copytobuffer(lons, inplace=inplace)
+        iny, y_data_type = _copytobuffer(lats, inplace=inplace)
+        inz, z_data_type = _copytobuffer(az, inplace=inplace)
+        ind = _copytobuffer(dist, inplace=inplace)[0]
         self._fwd(inx, iny, inz, ind, radians=radians)
         # if inputs were lists, tuples or floats, convert back.
         outx = _convertback(x_data_type, inx)
@@ -305,12 +317,15 @@ class Geod(_Geod):
         lons2: Any,
         lats2: Any,
         radians: bool = False,
+        inplace: bool = False,
     ) -> Tuple[Any, Any, Any]:
         """
         Inverse transformation
 
         Determine forward and back azimuths, plus distances
         between initial points and terminus points.
+
+        .. versionadded:: 3.5.0 inplace
 
         Accepted numeric scalar or array:
 
@@ -338,6 +353,10 @@ class Geod(_Geod):
         radians: bool, default=False
             If True, the input data is assumed to be in radians.
             Otherwise, the data is assumed to be in degrees.
+        inplace: bool, default=False
+            If True, will attempt to write the results to the input array
+            instead of returning a new array. This will fail if the input
+            is not an array in C order with the double data type.
 
         Returns
         -------
@@ -350,10 +369,10 @@ class Geod(_Geod):
             in meters
         """
         # process inputs, making copies that support buffer API.
-        inx, x_data_type = _copytobuffer(lons1)
-        iny, y_data_type = _copytobuffer(lats1)
-        inz, z_data_type = _copytobuffer(lons2)
-        ind = _copytobuffer(lats2)[0]
+        inx, x_data_type = _copytobuffer(lons1, inplace=inplace)
+        iny, y_data_type = _copytobuffer(lats1, inplace=inplace)
+        inz, z_data_type = _copytobuffer(lons2, inplace=inplace)
+        ind = _copytobuffer(lats2, inplace=inplace)[0]
         self._inv(inx, iny, inz, ind, radians=radians)
         # if inputs were lists, tuples or floats, convert back.
         outx = _convertback(x_data_type, inx)

--- a/test/test_geod.py
+++ b/test/test_geod.py
@@ -658,6 +658,24 @@ def test_geod_inv_honours_input_types(lons1, lats1, lons2):
     assert isinstance(outz, type(lons2))
 
 
+def test_geod_fwd_inv_inplace():
+    gg = Geod(ellps="clrk66")
+    lon1pt = np.array([0], dtype=np.float64)
+    lat1pt = np.array([0], dtype=np.float64)
+    lon2pt = np.array([1], dtype=np.float64)
+    lat2pt = np.array([1], dtype=np.float64)
+
+    az12, az21, dist = gg.inv(lon1pt, lat1pt, lon2pt, lat2pt, inplace=True)
+    assert az12 is lon1pt
+    assert az21 is lat1pt
+    assert dist is lon2pt
+
+    endlon, endlat, backaz = gg.fwd(lon1pt, lat1pt, az12, dist, inplace=True)
+    assert endlon is lon1pt
+    assert endlat is lat1pt
+    assert backaz is az12
+
+
 @pytest.mark.parametrize("kwarg", ["b", "f", "es", "rf", "e"])
 def test_geod__build_kwargs(kwarg):
     gg = Geod(ellps="clrk66")


### PR DESCRIPTION
This adds the ability to reuse the arrays passed in and out of the geod functions, following the same idea as the Transformers. I noticed this while profiling some of Cartopy's code and we could potentially get some speedup over there from this. We spend a lot of time in `_copytobuffer`.

I'm not sure if you would want the inplace applied to all potential inputs (i.e. `ind` as well) or just the outputs. Seems best to make it all to avoid the copy if possible.

 - [x] Tests added
 - [ ] Fully documented, including `history.rst` for all changes and `api/*.rst` for new API
