### PR TITLE
ENH: Add a fast-path for inplace transforms

### DIFF
--- a/pyproj/geod.py
+++ b/pyproj/geod.py
@@ -298,6 +298,9 @@ class Geod(_Geod):
         scalar or array:
             Back azimuth(s)
         """
+        if inplace:
+            self._fwd(lons, lats, az, dist, radians=radians)
+            return lons, lats, az
         # process inputs, making copies that support buffer API.
         inx, x_data_type = _copytobuffer(lons, inplace=inplace)
         iny, y_data_type = _copytobuffer(lats, inplace=inplace)
@@ -368,6 +371,9 @@ class Geod(_Geod):
             Distance(s) between initial and terminus point(s)
             in meters
         """
+        if inplace:
+            self._inv(lons1, lats1, lons2, lats2, radians=radians)
+            return lons1, lats1, lons2
         # process inputs, making copies that support buffer API.
         inx, x_data_type = _copytobuffer(lons1, inplace=inplace)
         iny, y_data_type = _copytobuffer(lats1, inplace=inplace)

--- a/pyproj/transformer.py
+++ b/pyproj/transformer.py
@@ -789,6 +789,22 @@ class Transformer:
         '33  98'
 
         """
+        if inplace and getattr(xx, "typecode", "") == "d":
+            self._transformer._transform(
+                xx,
+                yy,
+                inz=zz,
+                intime=tt,
+                direction=direction,
+                radians=radians,
+                errcheck=errcheck,
+            )
+            out = (xx, yy)
+            if zz is not None:
+                out += (zz,)
+            if tt is not None:
+                out += (tt,)
+            return out
         # process inputs, making copies that support buffer API.
         inx, x_data_type = _copytobuffer(xx, inplace=inplace)
         iny, y_data_type = _copytobuffer(yy, inplace=inplace)


### PR DESCRIPTION
Rather than opening an issue, I figured it would be easier to push up a PR with code for discussion purposes. This is looking at micro-optimizations when repeatedly calling `Transformer.transform()` on a single point at a time (yes, it is way better to make a large array first, but unfortunately that isn't always feasible). When transforming small arrays, there is a very large overhead (~40%) associated with calling into `_copytobuffer`/`_convertback` on every input/output array.

I'm wondering if anyone has any thoughts on making a fast-path for inplace arrays to bypass the utils functions? Right now the code is very friendly and if a user requests inplace, but the array doesn't work as input array it will gracefully transform it to an array that works, but this adds quite a few checks along the way that are inconsequential for large arrays, but make a difference for small arrays.

Essentially what I want is access to the private Cython inplace `_transform()` method, so perhaps another way to handle this would be to expose that in a public way somehow?

Benchmarking code:

```python
import array

import numpy as np
from pyproj import Transformer

transformer = Transformer.from_crs(2263, 4326)
x_coords = np.random.randint(80000, 120000)
y_coords = np.random.randint(200000, 250000)

x_np = x_coords * np.ones(1, dtype=np.float64)
y_np = y_coords * np.ones(1, dtype=np.float64)

x_list = x_np.tolist()
y_list = y_np.tolist()

x_arr = array.array('d', x_list)
y_arr = array.array('d', y_list)

# Repeat the calculation a bunch of times
for i in range(200000):
    # transformer.transform(x_np, x_np, inplace=False)
    # transformer.transform(x_np, x_np, inplace=True)
    # transformer.transform(x_list, y_list)
    # transformer.transform(x_arr, y_arr, inplace=False)
    transformer.transform(x_arr, y_arr, inplace=True)
```

Then running:
```
python -m cProfile -o prof-arr test_script.py
snakeviz prof-arr
```


 - [ ] Closes #xxxx
 - [ ] Tests added
 - [ ] Fully documented, including `history.rst` for all changes and `api/*.rst` for new API
