### PR TITLE
PERF: Optimize point transformations

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -23,4 +23,4 @@ disable=cyclic-import,
 
 
 [FORMAT]
-max-module-lines=1350
+max-module-lines=1500

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -3,14 +3,11 @@ Change Log
 
 Latest
 ------
-- ENH: Added :meth:`.Transformer.transform_point` (pull #1204)
-
-3.5.0
------
 - ENH: Add `return_back_azimuth: bool` to allow compatibility between the azimuth output of the following functions (issue #1163):
     `fwd` and `fwd_intermediate`, `inv` and `inv_intermediate`,
     Note: BREAKING CHANGE for the default value `return_back_azimuth=True` in the functions `fwd_intermediate` and `inv_intermediate`
     to mach the default value in `fwd` and `inv`
+- PERF: Optimize point transformations (pull #1204)
 
 3.4.1
 -----

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -3,6 +3,7 @@ Change Log
 
 Latest
 ------
+- ENH: Added :meth:`.Transformer.transform_point` (pull #1204)
 
 3.5.0
 -----

--- a/pyproj/_transformer.pyi
+++ b/pyproj/_transformer.pyi
@@ -1,3 +1,4 @@
+import numbers
 from array import array
 from typing import Any, List, NamedTuple, Optional, Tuple, Union
 
@@ -92,6 +93,16 @@ class _Transformer(Base):
         iny: Any,
         inz: Any,
         intime: Any,
+        direction: Union[TransformDirection, str],
+        radians: bool,
+        errcheck: bool,
+    ) -> None: ...
+    def _transform_point(
+        self,
+        inx: numbers.Real,
+        iny: numbers.Real,
+        inz: numbers.Real,
+        intime: numbers.Real,
         direction: Union[TransformDirection, str],
         radians: bool,
         errcheck: bool,

--- a/pyproj/_transformer.pyx
+++ b/pyproj/_transformer.pyx
@@ -722,20 +722,47 @@ cdef class _Transformer(Base):
     @cython.wraparound(False)
     def _transform_point(
         self,
-        double inx,
-        double iny,
-        double inz,
-        double intime,
+        object inx,
+        object iny,
+        object inz,
+        object intime,
         object direction,
         bint radians,
         bint errcheck,
     ):
+        """
+        Optimized to transform a single point between two coordinate systems.
+        """
+        cdef double coord_x = inx
+        cdef double coord_y = iny
+        cdef double coord_z = 0
+        cdef double coord_t = HUGE_VAL
+        cdef tuple expected_numeric_types = (int, float)
+        if not isinstance(inx, expected_numeric_types):
+            raise TypeError("Scalar input expected for x")
+        if not isinstance(iny, expected_numeric_types):
+            raise TypeError("Scalar input expected for y")
+        if inz is not None:
+            if not isinstance(inz, expected_numeric_types):
+                raise TypeError("Scalar input expected for z")
+            coord_z = inz
+        if intime is not None:
+            if not isinstance(intime, expected_numeric_types):
+                raise TypeError("Scalar input expected for t")
+            coord_t = intime
+
+        cdef tuple return_data
         if self.id == "noop":
-            return inx, iny, inz, intime
+            return_data = (inx, iny)
+            if inz is not None:
+                return_data += (inz,)
+            if intime is not None:
+                return_data += (intime,)
+            return return_data
 
         cdef PJ_DIRECTION pj_direction = get_pj_direction(direction)
         cdef PJ_COORD projxyout
-        cdef PJ_COORD projxyin = proj_coord(inx, iny, inz, intime)
+        cdef PJ_COORD projxyin = proj_coord(coord_x, coord_y, coord_z, coord_t)
         with nogil:
             # degrees to radians
             if not radians and proj_angular_input(self.projobj, pj_direction):
@@ -756,7 +783,7 @@ cdef class _Transformer(Base):
                     )
             elif errcheck:
                 with gil:
-                    if ProjError.internal_proj_error is not None:
+                    if _clear_proj_error() is not None:
                         raise ProjError("transform error")
 
             # radians to degrees
@@ -767,8 +794,14 @@ cdef class _Transformer(Base):
             elif radians and proj_degree_output(self.projobj, pj_direction):
                 projxyout.xy.x *= _DG2RAD
                 projxyout.xy.y *= _DG2RAD
-        ProjError.clear()
-        return projxyout.xyzt.x, projxyout.xyzt.y, projxyout.xyzt.z, projxyout.xyzt.t
+        _clear_proj_error()
+
+        return_data = (projxyout.xyzt.x, projxyout.xyzt.y)
+        if inz is not None:
+            return_data += (projxyout.xyzt.z,)
+        if intime is not None:
+            return_data += (projxyout.xyzt.t,)
+        return return_data
 
     @cython.boundscheck(False)
     @cython.wraparound(False)

--- a/pyproj/proj.pxi
+++ b/pyproj/proj.pxi
@@ -99,6 +99,7 @@ cdef extern from "proj.h" nogil:
     int proj_degree_input (PJ *P, PJ_DIRECTION dir)
     int proj_degree_output (PJ *P, PJ_DIRECTION dir)
 
+    PJ_COORD proj_trans (PJ *P, PJ_DIRECTION direction, PJ_COORD coord)
     size_t proj_trans_generic (
         PJ *P,
         PJ_DIRECTION direction,

--- a/pyproj/transformer.py
+++ b/pyproj/transformer.py
@@ -8,6 +8,8 @@ __all__ = [
     "TransformerGroup",
     "AreaOfInterest",
 ]
+import math
+import numbers
 import threading
 import warnings
 from abc import ABC, abstractmethod
@@ -818,6 +820,105 @@ class Transformer:
             return_data += (_convertback(z_data_type, inz),)
         if intime is not None:
             return_data += (_convertback(t_data_type, intime),)
+        return return_data
+
+    @overload
+    def transform_point(  # pylint: disable=invalid-name
+        self,
+        xx: numbers.Real,
+        yy: numbers.Real,
+        radians: bool = False,
+        errcheck: bool = False,
+        direction: Union[TransformDirection, str] = TransformDirection.FORWARD,
+    ) -> Tuple[float, float]:
+        ...
+
+    @overload
+    def transform_point(  # pylint: disable=invalid-name
+        self,
+        xx: numbers.Real,
+        yy: numbers.Real,
+        zz: numbers.Real,
+        radians: bool = False,
+        errcheck: bool = False,
+        direction: Union[TransformDirection, str] = TransformDirection.FORWARD,
+    ) -> Tuple[float, float, float]:
+        ...
+
+    @overload
+    def transform_point(  # pylint: disable=invalid-name
+        self,
+        xx: numbers.Real,
+        yy: numbers.Real,
+        zz: numbers.Real,
+        tt: numbers.Real,
+        radians: bool = False,
+        errcheck: bool = False,
+        direction: Union[TransformDirection, str] = TransformDirection.FORWARD,
+    ) -> Tuple[float, float, float, float]:
+        ...
+
+    def transform_point(  # pylint: disable=invalid-name
+        self,
+        xx,
+        yy,
+        zz=None,
+        tt=None,
+        radians=False,
+        errcheck=False,
+        direction=TransformDirection.FORWARD,
+    ):
+        """
+        Optimized to transform a single point between two coordinate systems.
+
+        See: :c:func:`proj_trans`
+
+        .. versionadded:: 3.5.0
+
+        Examples of accepted numeric scalar:
+
+        - :class:`int`
+        - :class:`float`
+        - :class:`numpy.floating`
+        - :class:`numpy.integer`
+
+        Parameters
+        ----------
+        xx: numbers.Real
+            Input x coordinate.
+        yy: numbers.Real
+            Input y coordinate.
+        zz: numbers.Real, optional
+            Input z coordinate.
+        tt: numbers.Real, optional
+            Input time coordinate.
+        radians: bool, default=False
+            If True, will expect input data to be in radians and will return radians
+            if the projection is geographic. Otherwise, it uses degrees.
+            Ignored for pipeline transformations with pyproj 2,
+            but will work in pyproj 3.
+        errcheck: bool, default=False
+            If True, an exception is raised if the errors are found in the process.
+            If False, ``inf`` is returned for errors.
+        direction: pyproj.enums.TransformDirection, optional
+            The direction of the transform.
+            Default is :attr:`pyproj.enums.TransformDirection.FORWARD`.
+
+        """
+        outx, outy, outz, outt = self._transformer._transform_point(
+            xx,
+            yy,
+            inz=0 if zz is None else zz,
+            intime=math.inf if tt is None else tt,
+            direction=direction,
+            radians=radians,
+            errcheck=errcheck,
+        )
+        return_data: Tuple[float, ...] = (outx, outy)
+        if zz is not None:
+            return_data += (outz,)
+        if tt is not None:
+            return_data += (outt,)
         return return_data
 
     def itransform(

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -3,6 +3,8 @@ import pickle
 from contextlib import contextmanager
 from pathlib import Path
 
+import numpy
+import pytest
 from packaging import version
 
 import pyproj
@@ -89,3 +91,27 @@ def assert_can_pickle(raw_obj, tmp_path):
         unpickled = pickle.load(f)
 
     assert raw_obj == unpickled
+
+
+def _make_longer_array(data: float):
+    """
+    Turn the float into a 2-element array
+    """
+    return numpy.array([data] * 2)
+
+
+@pytest.fixture(
+    params=[
+        float,
+        numpy.array,
+        _make_longer_array,
+    ]
+)
+def scalar_and_array(request):
+    """
+    Ensure cython methods are tested
+    with scalar and arrays to trigger
+    point optimized functions as well
+    as the main functions supporting arrays.
+    """
+    return request.param

--- a/test/test_transformer.py
+++ b/test/test_transformer.py
@@ -27,19 +27,6 @@ from test.conftest import (
 )
 
 
-@pytest.fixture(
-    params=[
-        "transform",
-        "transform_point",
-    ]
-)
-def transform_point_method(request):
-    """
-    Test both Transformer.transform and Transformer.transform_point
-    """
-    return request.param
-
-
 def test_tranform_wgs84_to_custom():
     custom_proj = pyproj.Proj(
         "+proj=geos +lon_0=0.000000 +lat_0=0 +h=35807.414063"
@@ -98,33 +85,55 @@ def test_lambert_conformal_transform():
     assert_almost_equal((Long1, Lat1, H1), (-4.6753456, 32.902199, 1341.467), decimal=5)
 
 
-def test_4d_transform(transform_point_method):
+def test_4d_transform(scalar_and_array):
     transformer = Transformer.from_pipeline("+init=ITRF2008:ITRF2000")
     assert_almost_equal(
-        getattr(transformer, transform_point_method)(
-            xx=3513638.19380, yy=778956.45250, zz=5248216.46900, tt=2008.75
+        transformer.transform(
+            xx=scalar_and_array(3513638.19380),
+            yy=scalar_and_array(778956.45250),
+            zz=scalar_and_array(5248216.46900),
+            tt=scalar_and_array(2008.75),
         ),
-        (3513638.1999428216, 778956.4532640711, 5248216.453456361, 2008.75),
+        (
+            scalar_and_array(3513638.1999428216),
+            scalar_and_array(778956.4532640711),
+            scalar_and_array(5248216.453456361),
+            scalar_and_array(2008.75),
+        ),
     )
 
 
-def test_2d_with_time_transform(transform_point_method):
+def test_2d_with_time_transform(scalar_and_array):
     transformer = Transformer.from_pipeline("+init=ITRF2008:ITRF2000")
     assert_almost_equal(
-        getattr(transformer, transform_point_method)(
-            xx=3513638.19380, yy=778956.45250, tt=2008.75
+        transformer.transform(
+            xx=scalar_and_array(3513638.19380),
+            yy=scalar_and_array(778956.45250),
+            tt=scalar_and_array(2008.75),
         ),
-        (3513638.1999428216, 778956.4532640711, 2008.75),
+        (
+            scalar_and_array(3513638.1999428216),
+            scalar_and_array(778956.4532640711),
+            scalar_and_array(2008.75),
+        ),
     )
 
 
-def test_4d_transform_crs_obs1(transform_point_method):
+def test_4d_transform_crs_obs1(scalar_and_array):
     transformer = Transformer.from_proj(7789, 8401)
     assert_almost_equal(
-        getattr(transformer, transform_point_method)(
-            xx=3496737.2679, yy=743254.4507, zz=5264462.9620, tt=2019.0
+        transformer.transform(
+            xx=scalar_and_array(3496737.2679),
+            yy=scalar_and_array(743254.4507),
+            zz=scalar_and_array(5264462.9620),
+            tt=scalar_and_array(2019.0),
         ),
-        (3496737.757717311, 743253.9940103051, 5264462.701132784, 2019.0),
+        (
+            scalar_and_array(3496737.757717311),
+            scalar_and_array(743253.9940103051),
+            scalar_and_array(5264462.701132784),
+            scalar_and_array(2019.0),
+        ),
     )
 
 
@@ -138,23 +147,37 @@ def test_4d_transform_orginal_crs_obs1():
         )
 
 
-def test_4d_transform_crs_obs2(transform_point_method):
+def test_4d_transform_crs_obs2(scalar_and_array):
     transformer = Transformer.from_proj(4896, 7930)
     assert_almost_equal(
-        getattr(transformer, transform_point_method)(
-            xx=3496737.2679, yy=743254.4507, zz=5264462.9620, tt=2019.0
+        transformer.transform(
+            xx=scalar_and_array(3496737.2679),
+            yy=scalar_and_array(743254.4507),
+            zz=scalar_and_array(5264462.9620),
+            tt=scalar_and_array(2019.0),
         ),
-        (3496737.7857162016, 743254.0394113371, 5264462.643659916, 2019.0),
+        (
+            scalar_and_array(3496737.7857162016),
+            scalar_and_array(743254.0394113371),
+            scalar_and_array(5264462.643659916),
+            scalar_and_array(2019.0),
+        ),
     )
 
 
-def test_2d_with_time_transform_crs_obs2(transform_point_method):
+def test_2d_with_time_transform_crs_obs2(scalar_and_array):
     transformer = Transformer.from_proj(4896, 7930)
     assert_almost_equal(
-        getattr(transformer, transform_point_method)(
-            xx=3496737.2679, yy=743254.4507, tt=2019.0
+        transformer.transform(
+            xx=scalar_and_array(3496737.2679),
+            yy=scalar_and_array(743254.4507),
+            tt=scalar_and_array(2019.0),
         ),
-        (3496737.4105305015, 743254.1014318303, 2019.0),
+        (
+            scalar_and_array(3496737.4105305015),
+            scalar_and_array(743254.1014318303),
+            scalar_and_array(2019.0),
+        ),
     )
 
 
@@ -257,11 +280,13 @@ def test_transform_no_exception():
     transformer.itransform([(1.716073972, 52.658007833)], errcheck=True)
 
 
-def test_transform__out_of_bounds(transform_point_method):
+def test_transform__out_of_bounds(scalar_and_array):
     with pytest.warns(FutureWarning):
         transformer = Transformer.from_proj("+init=epsg:4326", "+init=epsg:27700")
     with pytest.raises(pyproj.exceptions.ProjError):
-        getattr(transformer, transform_point_method)(100000, 100000, errcheck=True)
+        transformer.transform(
+            scalar_and_array(100000), scalar_and_array(100000), errcheck=True
+        )
 
 
 def test_transform_radians():
@@ -319,38 +344,55 @@ def test_itransform_radians():
         )
 
 
-def test_4d_transform__inverse(transform_point_method):
+def test_4d_transform__inverse(scalar_and_array):
     transformer = Transformer.from_pipeline("+init=ITRF2008:ITRF2000")
     assert_almost_equal(
-        getattr(transformer, transform_point_method)(
-            xx=3513638.1999428216,
-            yy=778956.4532640711,
-            zz=5248216.453456361,
-            tt=2008.75,
+        transformer.transform(
+            xx=scalar_and_array(3513638.1999428216),
+            yy=scalar_and_array(778956.4532640711),
+            zz=scalar_and_array(5248216.453456361),
+            tt=scalar_and_array(2008.75),
             direction=TransformDirection.INVERSE,
         ),
-        (3513638.19380, 778956.45250, 5248216.46900, 2008.75),
+        (
+            scalar_and_array(3513638.19380),
+            scalar_and_array(778956.45250),
+            scalar_and_array(5248216.46900),
+            scalar_and_array(2008.75),
+        ),
     )
 
 
-def test_transform_direction(transform_point_method):
+def test_transform_direction(scalar_and_array):
     forward_transformer = Transformer.from_crs(4326, 3857)
     inverse_transformer = Transformer.from_crs(3857, 4326)
-    assert getattr(inverse_transformer, transform_point_method)(
-        -33, 24, direction=TransformDirection.INVERSE
-    ) == getattr(forward_transformer, transform_point_method)(-33, 24)
+    assert_array_equal(
+        inverse_transformer.transform(
+            scalar_and_array(-33),
+            scalar_and_array(24),
+            direction=TransformDirection.INVERSE,
+        ),
+        forward_transformer.transform(scalar_and_array(-33), scalar_and_array(24)),
+    )
     ident_transformer = Transformer.from_crs(4326, 3857)
-    ident_transformer.transform(-33, 24, direction=TransformDirection.IDENT) == (
-        -33,
-        24,
+    assert_array_equal(
+        ident_transformer.transform(
+            scalar_and_array(-33),
+            scalar_and_array(24),
+            direction=TransformDirection.IDENT,
+        ),
+        (scalar_and_array(-33), scalar_and_array(24)),
     )
 
 
-def test_always_xy__transformer(transform_point_method):
+def test_always_xy__transformer(scalar_and_array):
     transformer = Transformer.from_crs(2193, 4326, always_xy=True)
     assert_almost_equal(
-        getattr(transformer, transform_point_method)(1625350, 5504853),
-        (173.29964730317386, -40.60674802693758),
+        transformer.transform(scalar_and_array(1625350), scalar_and_array(5504853)),
+        (
+            scalar_and_array(173.29964730317386),
+            scalar_and_array(-40.60674802693758),
+        ),
     )
 
 
@@ -387,34 +429,52 @@ def test_transform_empty_array_xyzt(empty_array):
     )
 
 
-def test_transform_direction__string(transform_point_method):
+def test_transform_direction__string(scalar_and_array):
     forward_transformer = Transformer.from_crs(4326, 3857)
     inverse_transformer = Transformer.from_crs(3857, 4326)
-    assert getattr(inverse_transformer, transform_point_method)(
-        -33, 24, direction="INVERSE"
-    ) == getattr(forward_transformer, transform_point_method)(
-        -33, 24, direction="FORWARD"
+    assert_array_equal(
+        inverse_transformer.transform(
+            scalar_and_array(-33), scalar_and_array(24), direction="INVERSE"
+        ),
+        forward_transformer.transform(
+            scalar_and_array(-33), scalar_and_array(24), direction="FORWARD"
+        ),
     )
     ident_transformer = Transformer.from_crs(4326, 3857)
-    ident_transformer.transform(-33, 24, direction="IDENT") == (-33, 24)
+    assert_array_equal(
+        ident_transformer.transform(
+            scalar_and_array(-33), scalar_and_array(24), direction="IDENT"
+        ),
+        (scalar_and_array(-33), scalar_and_array(24)),
+    )
 
 
-def test_transform_direction__string_lowercase(transform_point_method):
+def test_transform_direction__string_lowercase(scalar_and_array):
     forward_transformer = Transformer.from_crs(4326, 3857)
     inverse_transformer = Transformer.from_crs(3857, 4326)
-    assert getattr(inverse_transformer, transform_point_method)(
-        -33, 24, direction="inverse"
-    ) == getattr(forward_transformer, transform_point_method)(
-        -33, 24, direction="forward"
+    assert_array_equal(
+        inverse_transformer.transform(
+            scalar_and_array(-33), scalar_and_array(24), direction="inverse"
+        ),
+        forward_transformer.transform(
+            scalar_and_array(-33), scalar_and_array(24), direction="forward"
+        ),
     )
     ident_transformer = Transformer.from_crs(4326, 3857)
-    ident_transformer.transform(-33, 24, direction="ident") == (-33, 24)
+    assert_array_equal(
+        ident_transformer.transform(
+            scalar_and_array(-33), scalar_and_array(24), direction="ident"
+        ),
+        (scalar_and_array(-33), scalar_and_array(24)),
+    )
 
 
-def test_transform_direction__invalid(transform_point_method):
+def test_transform_direction__invalid(scalar_and_array):
     transformer = Transformer.from_crs(4326, 3857)
     with pytest.raises(ValueError, match="Invalid value"):
-        getattr(transformer, transform_point_method)(-33, 24, direction="WHEREVER")
+        transformer.transform(
+            scalar_and_array(-33), scalar_and_array(24), direction="WHEREVER"
+        )
 
 
 def test_from_pipeline__non_transform_input():


### PR DESCRIPTION
Related: #1202
```python
In [1]: from pyproj import Transformer

In [2]: transformer = Transformer.from_crs(4326, 3857, always_xy=True)

In [3]: %timeit transformer.transform(1, 2)
4.69 µs ± 37.9 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)

In [4]: %timeit transformer.transform_point(1, 2)
2.08 µs ± 20.2 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)
```
Version in #1203:
```python
In [5]: %timeit transformer.transform_point(1, 2)
2.99 µs ± 132 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)
```