### PR TITLE
PERF: Optimize for single point in Geod fwd/inv functions

### DIFF
--- a/pyproj/_geod.pyi
+++ b/pyproj/_geod.pyi
@@ -31,6 +31,15 @@ class Geod:
         radians: bool = False,
         return_back_azimuth: bool = True,
     ) -> None: ...
+    def _fwd_point(
+        self,
+        lons: float,
+        lats: float,
+        az: float,
+        dist: float,
+        radians: bool = False,
+        return_back_azimuth: bool = True,
+    ) -> Tuple[float, float, float]: ...
     def _inv(
         self,
         lons1: Any,
@@ -40,6 +49,15 @@ class Geod:
         radians: bool = False,
         return_back_azimuth: bool = False,
     ) -> None: ...
+    def _inv_point(
+        self,
+        lons1: float,
+        lats1: float,
+        lons2: float,
+        lats2: float,
+        radians: bool = False,
+        return_back_azimuth: bool = False,
+    ) -> Tuple[float, float, float]: ...
     def _inv_or_fwd_intermediate(
         self,
         lon1: float,

--- a/pyproj/geod.py
+++ b/pyproj/geod.py
@@ -294,7 +294,7 @@ class Geod(_Geod):
             instead of returning a new array. This will fail if the input
             is not an array in C order with the double data type.
         return_back_azimuth: bool, default=True
-            if True, the third return value will be the back azimuth,
+            If True, the third return value will be the back azimuth,
             Otherwise, it will be the forward azimuth.
 
         Returns
@@ -306,6 +306,20 @@ class Geod(_Geod):
         scalar or array:
             Back azimuth(s) or Forward azimuth(s)
         """
+        try:
+            # Fast-path for scalar input, will raise if invalid types are input
+            # and we can fallback below
+            return self._fwd_point(
+                lons,
+                lats,
+                az,
+                dist,
+                radians=radians,
+                return_back_azimuth=return_back_azimuth,
+            )
+        except TypeError:
+            pass
+
         # process inputs, making copies that support buffer API.
         inx, x_data_type = _copytobuffer(lons, inplace=inplace)
         iny, y_data_type = _copytobuffer(lats, inplace=inplace)
@@ -371,8 +385,8 @@ class Geod(_Geod):
             instead of returning a new array. This will fail if the input
             is not an array in C order with the double data type.
         return_back_azimuth: bool, default=True
-            if True, the second return value (azi21) will be the back azimuth
-            (flipped 180 degrees), Otherwise, it will be also a forward azimuth.
+            If True, the second return value (azi21) will be the back azimuth
+            (flipped 180 degrees), Otherwise, it will also be a forward azimuth.
 
         Returns
         -------
@@ -384,6 +398,20 @@ class Geod(_Geod):
             Distance(s) between initial and terminus point(s)
             in meters
         """
+        try:
+            # Fast-path for scalar input, will raise if invalid types are input
+            # and we can fallback below
+            return self._inv_point(
+                lons1,
+                lats1,
+                lons2,
+                lats2,
+                radians=radians,
+                return_back_azimuth=return_back_azimuth,
+            )
+        except TypeError:
+            pass
+
         # process inputs, making copies that support buffer API.
         inx, x_data_type = _copytobuffer(lons1, inplace=inplace)
         iny, y_data_type = _copytobuffer(lats1, inplace=inplace)

--- a/test/test_geod.py
+++ b/test/test_geod.py
@@ -678,6 +678,51 @@ def test_geod_fwd_honours_input_types(lon, lat, az):
     assert isinstance(outz, type(az))
 
 
+def test_geod_fwd_radians():
+    g = Geod(ellps="clrk66")
+    lon1 = 1
+    lat1 = 1
+    az1 = 1
+    dist = 1
+    assert_almost_equal(
+        np.rad2deg(g.fwd(lon1, lat1, az1, dist, radians=True)),
+        g.fwd(lon1 * 180 / np.pi, lat1 * 180 / np.pi, az1 * 180 / np.pi, dist),
+    )
+
+
+def test_geod_inv_radians():
+    g = Geod(ellps="clrk66")
+    lon1 = 0
+    lat1 = 0
+    lon2 = 1
+    lat2 = 1
+    # the third output is in distance, so we don't want to change from deg-rad there
+    out_rad = list(g.inv(lon1, lat1, lon2, lat2, radians=True))
+    out_rad[0] *= 180 / np.pi
+    out_rad[1] *= 180 / np.pi
+    assert_almost_equal(
+        out_rad,
+        g.inv(
+            lon1 * 180 / np.pi,
+            lat1 * 180 / np.pi,
+            lon2 * 180 / np.pi,
+            lat2 * 180 / np.pi,
+        ),
+    )
+
+
+@pytest.mark.parametrize("func_name", ("fwd", "inv"))
+@pytest.mark.parametrize("radians", (True, False))
+def test_geod_scalar_array(func_name, radians):
+    # verify two singlepoint calculations match an array of length two
+    g = Geod(ellps="clrk66")
+    func = getattr(g, func_name)
+    assert_almost_equal(
+        np.transpose([func(0, 0, 1, 1, radians=radians) for i in range(2)]),
+        func([0, 0], [0, 0], [1, 1], [1, 1], radians=radians),
+    )
+
+
 @pytest.mark.parametrize(
     "lons1,lats1,lons2", permutations([10.0, [10.0], (10.0,)])
 )  # 6 test cases


### PR DESCRIPTION
This adds a fast-path for scalar inputs by trying out a double-only implementation, and falling back if any input is not a double. An alternative is to add `Geod.fwd_point()` and `Geod.inv_point()` functions as well, but I kind of like this transparent form for simplicity of users only needing one function and only a minor overhead for arrays where you are already going through some slower paths.

A little under 10x improvement for scalars.
```python
In [1]: from pyproj import Geod

In [2]: g = Geod(ellps="WGS84")

In [3]: %timeit g.fwd([0], [0], [1], [1])
4.76 µs ± 28.5 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)

In [4]: %timeit g.fwd(0, 0, 1, 1)
588 ns ± 4.57 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)
```

 - [x] Tests added
