### PR TITLE
TST:geod: Separate geodesic tests for clarity

### DIFF
--- a/test/test_geod.py
+++ b/test/test_geod.py
@@ -1,13 +1,9 @@
-import itertools
 import math
-import os
 import pickle
-import shutil
-import tempfile
-from contextlib import contextmanager, nullcontext
+from contextlib import nullcontext
 from itertools import permutations
 
-import numpy as np
+import numpy
 import pytest
 from numpy.testing import assert_almost_equal
 
@@ -34,328 +30,419 @@ except (ImportError, OSError):
 skip_shapely = pytest.mark.skipif(not SHAPELY_LOADED, reason="Missing shapely")
 
 
-@contextmanager
-def temporary_directory():
-    """
-    Get a temporary directory
-    """
-    temp_dir = tempfile.mkdtemp()
-    try:
-        yield temp_dir
-    finally:
-        shutil.rmtree(temp_dir)
+# BOSTON
+_BOSTON_LAT = 42.0 + (15.0 / 60.0)
+_BOSTON_LON = -71.0 - (7.0 / 60.0)
+# PORTLAND
+_PORTLAND_LAT = 45.0 + (31.0 / 60.0)
+_PORTLAND_LON = -123.0 - (41.0 / 60.0)
 
 
-def test_geod_inverse_transform():
-    gg = Geod(ellps="clrk66")
-    lat1pt = 42.0 + (15.0 / 60.0)
-    lon1pt = -71.0 - (7.0 / 60.0)
-    lat2pt = 45.0 + (31.0 / 60.0)
-    lon2pt = -123.0 - (41.0 / 60.0)
-    """
-    distance between boston and portland, clrk66:
-    -66.531 75.654  4164192.708
-    distance between boston and portland, WGS84:
-    -66.530 75.654  4164074.239
-    testing pickling of Geod instance
-    distance between boston and portland, clrk66 (from pickle):
-    -66.531 75.654  4164192.708
-    distance between boston and portland, WGS84 (from pickle):
-    -66.530 75.654  4164074.239
-    inverse transform
-    from proj.4 invgeod:
-    b'-66.531\t75.654\t4164192.708\n'
+@pytest.mark.parametrize("return_back_azimuth", [True, False])
+@pytest.mark.parametrize(
+    "ellipsoid,true_az12,true_az21,expected_distance",
+    [
+        ("clrk66", -66.5305947876623, 75.65363415556968, 4164192.708),
+        ("WGS84", -66.5305947876623, 75.65363415556968, 4164074.239),
+    ],
+)
+def test_geodesic_inv(
+    ellipsoid, true_az12, true_az21, expected_distance, return_back_azimuth
+):
+    geod = Geod(ellps=ellipsoid)
+    az12, az21, dist = geod.inv(
+        _BOSTON_LON,
+        _BOSTON_LAT,
+        _PORTLAND_LON,
+        _PORTLAND_LAT,
+        return_back_azimuth=return_back_azimuth,
+    )
+    if not return_back_azimuth:
+        az21 = reverse_azimuth(az21)
+    assert_almost_equal(
+        (az12, az21, dist), (true_az12, true_az21, expected_distance), decimal=3
+    )
 
-    """
-    true_az12 = -66.5305947876623
-    true_az21 = 75.65363415556968
-    print("from pyproj.Geod.inv:")
-    for return_back_azimuth in (True, False):
-        az12, az21, dist = gg.inv(
-            lon1pt, lat1pt, lon2pt, lat2pt, return_back_azimuth=return_back_azimuth
-        )
-        if not return_back_azimuth:
-            az21 = reverse_azimuth(az21)
+
+@pytest.mark.parametrize(
+    "lon_start,lat_start,lon_end,lat_end,res12,res21,resdist",
+    [
+        (_BOSTON_LON, _BOSTON_LAT, _BOSTON_LON, _BOSTON_LAT, 180.0, 0.0, 0.0),
+        (
+            _BOSTON_LON,
+            _BOSTON_LAT,
+            -80.79664651607472,
+            44.83744724383204,
+            -66.53059478766238,
+            106.79071710136431,
+            832838.5416198927,
+        ),
+        (
+            -80.79664651607472,
+            44.83744724383204,
+            -91.21816704002396,
+            46.536201500764776,
+            -73.20928289863558,
+            99.32289055927389,
+            832838.5416198935,
+        ),
+        (
+            -91.21816704002396,
+            46.536201500764776,
+            -102.10621593474447,
+            47.236494630072166,
+            -80.67710944072617,
+            91.36325611787134,
+            832838.5416198947,
+        ),
+        (
+            -102.10621593474447,
+            47.236494630072166,
+            -113.06616309750775,
+            46.88821539471925,
+            -88.63674388212858,
+            83.32809401477382,
+            832838.5416198922,
+        ),
+        (
+            -113.06616309750775,
+            46.88821539471925,
+            _PORTLAND_LON,
+            _PORTLAND_LAT,
+            -96.67190598522616,
+            75.65363415556973,
+            832838.5416198926,
+        ),
+    ],
+)
+def test_geodesic_inv__multiple_points(
+    lon_start, lat_start, lon_end, lat_end, res12, res21, resdist
+):
+    geod = Geod(ellps="clrk66")
+    o_az12, o_az21, o_dist = geod.inv(lon_start, lat_start, lon_end, lat_end)
+    assert_almost_equal((o_az12, o_az21, o_dist), (res12, res21, resdist))
+
+
+@pytest.mark.parametrize(
+    "flag", [GeodIntermediateFlag.AZIS_DISCARD, GeodIntermediateFlag.AZIS_KEEP]
+)
+def test_geodesic_inv_intermediate__azis_flag(flag):
+    geod = Geod(ellps="clrk66")
+    point_count = 7
+    res = geod.inv_intermediate(
+        lon1=_BOSTON_LON,
+        lat1=_BOSTON_LAT,
+        lon2=_PORTLAND_LON,
+        lat2=_PORTLAND_LAT,
+        npts=point_count,
+        initial_idx=0,
+        terminus_idx=0,
+        flags=flag,
+        return_back_azimuth=False,
+    )
+    assert res.npts == point_count
+    assert_almost_equal(res.del_s, 694032.1180165777)
+    assert_almost_equal(res.dist, 4164192.7080994663)
+    assert_almost_equal(
+        res.lons,
+        [
+            _BOSTON_LON,
+            -79.12667425528419,
+            -87.67579185665936,
+            -96.62666097960022,
+            -105.7727853838606,
+            -114.86985739838673,
+            _PORTLAND_LON,
+        ],
+    )
+    assert_almost_equal(
+        res.lats,
+        [
+            _BOSTON_LAT,
+            44.46434542986116,
+            46.07643938331146,
+            47.0159762562249,
+            47.23724050253994,
+            46.72890509939583,
+            _PORTLAND_LAT,
+        ],
+    )
+    if flag == GeodIntermediateFlag.AZIS_DISCARD:
+        assert res.azis is None
+    else:
         assert_almost_equal(
-            (az12, az21, dist), (true_az12, true_az21, 4164192.708), decimal=3
+            res.azis,
+            [
+                -66.5305947876623,
+                -72.03560255472611,
+                -78.11540731053181,
+                -84.61959820187617,
+                -91.32904268899453,
+                -97.98697931255812,
+                -104.34636584443031,
+            ],
         )
 
-    print("forward transform")
-    print("from proj.4 geod:")
-    for return_back_azimuth in (True, False):
-        endlon, endlat, backaz = gg.fwd(
-            lon1pt, lat1pt, az12, dist, return_back_azimuth=return_back_azimuth
-        )
-        if not return_back_azimuth:
-            backaz = reverse_azimuth(backaz)
+
+@pytest.mark.parametrize(
+    "flag", [GeodIntermediateFlag.AZIS_DISCARD, GeodIntermediateFlag.AZIS_KEEP]
+)
+def test_geodesic_inv_intermediate__azis_flag__numpy(flag):
+    geod = Geod(ellps="clrk66")
+    point_count = 3
+    lons_b = numpy.empty(point_count)
+    lats_b = numpy.empty(point_count)
+    res = geod.inv_intermediate(
+        out_lons=lons_b,
+        out_lats=lats_b,
+        lon1=_BOSTON_LON,
+        lat1=_BOSTON_LAT,
+        lon2=_PORTLAND_LON,
+        lat2=_PORTLAND_LAT,
+        npts=point_count,
+        initial_idx=0,
+        terminus_idx=0,
+        flags=flag,
+        return_back_azimuth=False,
+    )
+    assert res.npts == point_count
+    assert_almost_equal(res.del_s, 2082096.3540497331)
+    assert_almost_equal(res.dist, 4164192.7080994663)
+    assert_almost_equal(res.lons, [_BOSTON_LON, -96.62666098, _PORTLAND_LON])
+    assert_almost_equal(
+        res.lats,
+        [_BOSTON_LAT, 47.01597626, _PORTLAND_LAT],
+    )
+    if flag == GeodIntermediateFlag.AZIS_DISCARD:
+        assert res.azis is None
+    else:
         assert_almost_equal(
-            (endlon, endlat, backaz), (lon2pt, lat2pt, true_az21), decimal=3
+            res.azis,
+            [-66.5305947876623, -84.61959820187617, -104.34636584443031],
         )
+    assert res.lons is lons_b
+    assert res.lats is lats_b
 
-    inc_exc = ["excluding", "including"]
-    res_az12_az21_dists_all = [
-        (180.0, 0.0, 0.0),
-        (-66.53059478766238, 106.79071710136431, 832838.5416198927),
-        (-73.20928289863558, 99.32289055927389, 832838.5416198935),
-        (-80.67710944072617, 91.36325611787134, 832838.5416198947),
-        (-88.63674388212858, 83.32809401477382, 832838.5416198922),
-        (-96.67190598522616, 75.65363415556973, 832838.5416198926),
-    ]
-    point_count = len(res_az12_az21_dists_all)
-    for include_initial, include_terminus in itertools.product(
-        (False, True), (False, True)
-    ):
-        initial_idx = int(not include_initial)
-        terminus_idx = int(not include_terminus)
 
-        npts = point_count - initial_idx - terminus_idx
-        print("intermediate points:")
-        print("from geod with +lat_1,+lon_1,+lat_2,+lon_2,+n_S:")
-        print(f"{lat1pt:6.3f} {lon1pt:7.3f} {lat2pt:6.3f} {lon2pt:7.3f} {npts}")
+@pytest.mark.parametrize("return_back_azimuth", [True, False])
+def test_geodesic_inv_intermediate__numpy(return_back_azimuth):
+    geod = Geod(ellps="clrk66")
+    point_count = 5
+    lons = numpy.empty(point_count)
+    lats = numpy.empty(point_count)
+    azis = numpy.empty(point_count)
 
-        lonlats = gg.npts(
-            lon1pt,
-            lat1pt,
-            lon2pt,
-            lat2pt,
-            npts,
-            initial_idx=initial_idx,
-            terminus_idx=terminus_idx,
-        )
-        assert len(lonlats) == npts
-
-        npts1 = npts + initial_idx + terminus_idx - 1
-        del_s = dist / npts1
-        print(
-            f"Total distance is {dist}, "
-            f"Points count: {npts}, "
-            f"{inc_exc[include_initial]} initial point, "
-            f"{inc_exc[include_terminus]} terminus point. "
-            f"The distance between successive points is {dist}/{npts1} = {del_s}"
-        )
-
-        from_idx = initial_idx
-        to_idx = point_count - terminus_idx
-        res_az12_az21_dists = res_az12_az21_dists_all[from_idx:to_idx]
-
-        lonprev = lon1pt
-        latprev = lat1pt
-        for (lon, lat), (res12, res21, resdist) in zip(lonlats, res_az12_az21_dists):
-            o_az12, o_az21, o_dist = gg.inv(lonprev, latprev, lon, lat)
-            if resdist == 0:
-                assert_almost_equal(o_dist, 0)
-            else:
-                assert_almost_equal((o_az12, o_az21, o_dist), (res12, res21, resdist))
-            latprev = lat
-            lonprev = lon
-        if not include_terminus:
-            o_az12, o_az21, o_dist = gg.inv(lonprev, latprev, lon2pt, lat2pt)
-            assert_almost_equal(
-                (lat2pt, lon2pt, o_dist), (45.517, -123.683, 832838.542), decimal=3
-            )
-
-        if include_initial and include_terminus:
-            lons, lats, azis12, azis21, dists = np.hstack(
-                (lonlats, res_az12_az21_dists)
-            ).transpose()
-
-    del_s = dist / (point_count - 1)
-    for return_back_azimuth in [None, True, False]:
-        print(f"test inv_intermediate (by npts) with azi output {return_back_azimuth=}")
-        lons_a = np.empty(point_count)
-        lats_a = np.empty(point_count)
-        azis_a = np.empty(point_count)
-
-        with pytest.warns(
-            UserWarning
-        ) if return_back_azimuth is None else nullcontext():
-            res = gg.inv_intermediate(
-                out_lons=lons_a,
-                out_lats=lats_a,
-                out_azis=azis_a,
-                lon1=lon1pt,
-                lat1=lat1pt,
-                lon2=lon2pt,
-                lat2=lat2pt,
-                npts=point_count,
-                initial_idx=0,
-                terminus_idx=0,
-                return_back_azimuth=return_back_azimuth,
-            )
-        assert res.npts == point_count
-        assert_almost_equal(res.del_s, del_s)
-        assert_almost_equal(res.dist, dist)
-        assert_almost_equal(res.lons, lons)
-        assert_almost_equal(res.lats, lats)
-        out_azis = res.azis[:-1]
-        if return_back_azimuth in [True, None]:
-            out_azis = reverse_azimuth(out_azis)
-        assert_almost_equal(out_azis, azis12[1:])
-        assert res.lons is lons_a
-        assert res.lats is lats_a
-        assert res.azis is azis_a
-
-    for flags in (GeodIntermediateFlag.AZIS_DISCARD, GeodIntermediateFlag.AZIS_KEEP):
-        print("test inv_intermediate (by npts) without azi output, no buffers")
-        res = gg.inv_intermediate(
-            lon1=lon1pt,
-            lat1=lat1pt,
-            lon2=lon2pt,
-            lat2=lat2pt,
+    with pytest.warns(UserWarning) if return_back_azimuth is None else nullcontext():
+        res = geod.inv_intermediate(
+            out_lons=lons,
+            out_lats=lats,
+            out_azis=azis,
+            lon1=_BOSTON_LON,
+            lat1=_BOSTON_LAT,
+            lon2=_PORTLAND_LON,
+            lat2=_PORTLAND_LAT,
             npts=point_count,
             initial_idx=0,
             terminus_idx=0,
-            flags=flags,
-            return_back_azimuth=False,
+            return_back_azimuth=return_back_azimuth,
         )
-        assert res.npts == point_count
-        assert_almost_equal(res.del_s, del_s)
-        assert_almost_equal(res.dist, dist)
-        assert_almost_equal(res.lons, lons_a)
-        assert_almost_equal(res.lats, lats_a)
-        if flags == GeodIntermediateFlag.AZIS_DISCARD:
-            assert res.azis is None
-        else:
-            assert_almost_equal(res.azis, azis_a)
+    assert res.npts == point_count
+    assert_almost_equal(res.del_s, 1041048.1770248666)
+    assert_almost_equal(res.dist, 4164192.7080994663)
+    assert_almost_equal(
+        res.lons,
+        [_BOSTON_LON, -83.34061499, -96.62666098, -110.34292364, _PORTLAND_LON],
+    )
+    assert_almost_equal(
+        res.lats, [_BOSTON_LAT, 45.35049848, 47.01597626, 47.07350417, _PORTLAND_LAT]
+    )
+    out_azis = res.azis[:-1]
+    if return_back_azimuth in [True, None]:
+        out_azis = reverse_azimuth(out_azis)
+    assert_almost_equal(
+        out_azis, [-66.53059479, -75.01125433, -84.6195982, -94.68069764]
+    )
+    assert res.lons is lons
+    assert res.lats is lats
+    assert res.azis is azis
 
-        lons_b = np.empty(point_count)
-        lats_b = np.empty(point_count)
-        azis_b = np.empty(point_count)
 
-        print("test inv_intermediate (by npts) without azi output")
-        res = gg.inv_intermediate(
-            out_lons=lons_b,
-            out_lats=lats_b,
-            out_azis=None,
-            lon1=lon1pt,
-            lat1=lat1pt,
-            lon2=lon2pt,
-            lat2=lat2pt,
-            npts=point_count,
-            initial_idx=0,
-            terminus_idx=0,
-            flags=flags,
-            return_back_azimuth=False,
-        )
-        assert res.npts == point_count
-        assert res.lons is lons_b
-        assert res.lats is lats_b
-        if flags == GeodIntermediateFlag.AZIS_DISCARD:
-            assert res.azis is None
-        else:
-            assert_almost_equal(res.azis, azis_a)
-        assert_almost_equal(res.del_s, del_s)
-        assert_almost_equal(res.dist, dist)
-        assert_almost_equal(res.lons, lons_a)
-        assert_almost_equal(res.lats, lats_a)
-
-    for return_back_azimuth in [False, True, None]:
-        print(f"test fwd_intermediate with {return_back_azimuth=}")
-        lons_b = np.empty(point_count)
-        lats_b = np.empty(point_count)
-        azis_b = np.empty(point_count)
-
-        with pytest.warns(
-            UserWarning
-        ) if return_back_azimuth is None else nullcontext():
-            res = gg.fwd_intermediate(
-                out_lons=lons_b,
-                out_lats=lats_b,
-                out_azis=azis_b,
-                lon1=lon1pt,
-                lat1=lat1pt,
-                azi1=true_az12,
-                npts=point_count,
-                del_s=del_s,
-                initial_idx=0,
-                terminus_idx=0,
-                return_back_azimuth=return_back_azimuth,
-            )
-        assert res.npts == point_count
-        assert res.lons is lons_b
-        assert res.lats is lats_b
-        assert res.azis is azis_b
-        assert_almost_equal(res.del_s, del_s)
-        assert_almost_equal(res.dist, dist)
-        assert_almost_equal(res.lons, lons_a)
-        assert_almost_equal(res.lats, lats_a)
-        if return_back_azimuth in [True, None]:
-            azis_b = reverse_azimuth(azis_b)
-        assert_almost_equal(azis_b, azis_a)
-
-    print("test inv_intermediate (by del_s)")
-    for del_s_fact, flags in (
+@pytest.mark.parametrize(
+    "del_s_fact,flag",
+    [
         (1, GeodIntermediateFlag.NPTS_ROUND),
-        ((point_count - 0.5) / point_count, GeodIntermediateFlag.NPTS_TRUNC),
-        ((point_count + 0.5) / point_count, GeodIntermediateFlag.NPTS_CEIL),
-    ):
-        res = gg.inv_intermediate(
-            out_lons=lons_b,
-            out_lats=lats_b,
-            out_azis=azis_b,
-            lon1=lon1pt,
-            lat1=lat1pt,
-            lon2=lon2pt,
-            lat2=lat2pt,
-            del_s=del_s * del_s_fact,
+        (4.5 / 5, GeodIntermediateFlag.NPTS_TRUNC),
+        (5.5 / 5, GeodIntermediateFlag.NPTS_CEIL),
+    ],
+)
+def test_geodesic_inv_intermediate__del_s__numpy(del_s_fact, flag):
+    geod = Geod(ellps="clrk66")
+    point_count = 5
+    lons = numpy.empty(point_count)
+    lats = numpy.empty(point_count)
+    azis = numpy.empty(point_count)
+    dist = 4164192.7080994663
+    del_s = dist / (point_count - 1)
+    res = geod.inv_intermediate(
+        out_lons=lons,
+        out_lats=lats,
+        out_azis=azis,
+        lon1=_BOSTON_LON,
+        lat1=_BOSTON_LAT,
+        lon2=_PORTLAND_LON,
+        lat2=_PORTLAND_LAT,
+        del_s=del_s * del_s_fact,
+        initial_idx=0,
+        terminus_idx=0,
+        flags=flag,
+        return_back_azimuth=False,
+    )
+    assert res.npts == point_count
+    assert_almost_equal(res.del_s, del_s)
+    assert_almost_equal(res.dist, dist)
+    assert_almost_equal(
+        res.lons,
+        [_BOSTON_LON, -83.34061499, -96.62666098, -110.34292364, _PORTLAND_LON],
+    )
+    assert_almost_equal(
+        res.lats, [_BOSTON_LAT, 45.35049848, 47.01597626, 47.07350417, _PORTLAND_LAT]
+    )
+    assert_almost_equal(
+        res.azis[:-1], [-66.53059479, -75.01125433, -84.6195982, -94.68069764]
+    )
+    assert res.lons is lons
+    assert res.lats is lats
+    assert res.azis is azis
+
+
+@pytest.mark.parametrize("return_back_azimuth", [True, False])
+def test_geodesic_fwd_intermediate__numpy(return_back_azimuth):
+    geod = Geod(ellps="clrk66")
+    point_count = 5
+    lons = numpy.empty(point_count)
+    lats = numpy.empty(point_count)
+    azis = numpy.empty(point_count)
+    true_az12 = -66.5305947876623
+    dist = 4164192.7080994663
+    del_s = dist / (point_count - 1)
+    with pytest.warns(UserWarning) if return_back_azimuth is None else nullcontext():
+        res = geod.fwd_intermediate(
+            out_lons=lons,
+            out_lats=lats,
+            out_azis=azis,
+            lon1=_BOSTON_LON,
+            lat1=_BOSTON_LAT,
+            azi1=true_az12,
+            npts=point_count,
+            del_s=del_s,
             initial_idx=0,
             terminus_idx=0,
-            flags=flags,
-            return_back_azimuth=False,
+            return_back_azimuth=return_back_azimuth,
         )
-        assert res.npts == point_count
-        assert_almost_equal(res.del_s, del_s)
-        assert_almost_equal(res.dist, dist)
-        assert_almost_equal(res.lons, lons_a)
-        assert_almost_equal(res.lats, lats_a)
-        assert_almost_equal(res.azis, azis_a)
-        assert res.lons is lons_b
-        assert res.lats is lats_b
-        assert res.azis is azis_b
+    assert res.npts == point_count
+    assert res.lons is lons
+    assert res.lats is lats
+    assert res.azis is azis
+    assert_almost_equal(res.del_s, del_s)
+    assert_almost_equal(res.dist, dist)
+    assert_almost_equal(
+        res.lons,
+        [-71.11666667, -83.34061499, -96.62666098, -110.34292364, -123.68333333],
+    )
+    assert_almost_equal(
+        res.lats, [42.25, 45.35049848, 47.01597626, 47.07350417, 45.51666667]
+    )
+    if return_back_azimuth in [True, None]:
+        azis = reverse_azimuth(azis)
+    assert_almost_equal(
+        azis, [-66.53059479, -75.01125433, -84.6195982, -94.68069764, -104.34636584]
+    )
 
 
-def test_geod_cities():
-    # specify the lat/lons of some cities.
-    boston_lat = 42.0 + (15.0 / 60.0)
-    boston_lon = -71.0 - (7.0 / 60.0)
-    portland_lat = 45.0 + (31.0 / 60.0)
-    portland_lon = -123.0 - (41.0 / 60.0)
-    g1 = Geod(ellps="clrk66")
-    g2 = Geod(ellps="WGS84")
-    az12, az21, dist = g1.inv(boston_lon, boston_lat, portland_lon, portland_lat)
-    print("distance between boston and portland, clrk66:")
-    print("%7.3f %6.3f %12.3f" % (az12, az21, dist))
-    assert_almost_equal((az12, az21, dist), (-66.531, 75.654, 4164192.708), decimal=3)
-    print("distance between boston and portland, WGS84:")
-    az12, az21, dist = g2.inv(boston_lon, boston_lat, portland_lon, portland_lat)
-    assert_almost_equal((az12, az21, dist), (-66.530, 75.654, 4164074.239), decimal=3)
-    print("%7.3f %6.3f %12.3f" % (az12, az21, dist))
-    print("testing pickling of Geod instance")
-    with temporary_directory() as tmpdir:
-        with open(os.path.join(tmpdir, "geod1.pickle"), "wb") as gp1w:
-            pickle.dump(g1, gp1w, -1)
-        with open(os.path.join(tmpdir, "geod2.pickle"), "wb") as gp2w:
-            pickle.dump(g2, gp2w, -1)
-        with open(os.path.join(tmpdir, "geod1.pickle"), "rb") as gp1:
-            g3 = pickle.load(gp1)
-        with open(os.path.join(tmpdir, "geod2.pickle"), "rb") as gp2:
-            g4 = pickle.load(gp2)
-    az12, az21, dist = g3.inv(boston_lon, boston_lat, portland_lon, portland_lat)
-    assert_almost_equal((az12, az21, dist), (-66.531, 75.654, 4164192.708), decimal=3)
-    print("distance between boston and portland, clrk66 (from pickle):")
-    print("%7.3f %6.3f %12.3f" % (az12, az21, dist))
-    az12, az21, dist = g4.inv(boston_lon, boston_lat, portland_lon, portland_lat)
-    print("distance between boston and portland, WGS84 (from pickle):")
-    print("%7.3f %6.3f %12.3f" % (az12, az21, dist))
-    assert_almost_equal((az12, az21, dist), (-66.530, 75.654, 4164074.239), decimal=3)
-    g3 = Geod("+ellps=clrk66")  # proj4 style init string
-    print("inverse transform")
-    lat1pt = 42.0 + (15.0 / 60.0)
-    lon1pt = -71.0 - (7.0 / 60.0)
-    lat2pt = 45.0 + (31.0 / 60.0)
-    lon2pt = -123.0 - (41.0 / 60.0)
-    az12, az21, dist = g3.inv(lon1pt, lat1pt, lon2pt, lat2pt)
-    print("%7.3f %6.3f %12.3f" % (az12, az21, dist))
+@pytest.mark.parametrize("return_back_azimuth", [True, False])
+@pytest.mark.parametrize(
+    "ellipsoid,true_az12,true_az21,expected_distance",
+    [
+        ("clrk66", -66.5305947876623, 75.65363415556968, 4164192.708),
+        ("WGS84", -66.5305947876623, 75.65363415556968, 4164074.239),
+    ],
+)
+def test_geodesic_fwd(
+    ellipsoid, true_az12, true_az21, expected_distance, return_back_azimuth
+):
+    geod = Geod(ellps=ellipsoid)
+    endlon, endlat, backaz = geod.fwd(
+        _BOSTON_LON,
+        _BOSTON_LAT,
+        true_az12,
+        expected_distance,
+        return_back_azimuth=return_back_azimuth,
+    )
+    if not return_back_azimuth:
+        backaz = reverse_azimuth(backaz)
+    assert_almost_equal(
+        (endlon, endlat, backaz), (_PORTLAND_LON, _PORTLAND_LAT, true_az21), decimal=3
+    )
+
+
+@pytest.mark.parametrize("include_initial", [True, False])
+@pytest.mark.parametrize("include_terminus", [True, False])
+def test_geodesic_npts(include_initial, include_terminus):
+    geod = Geod(ellps="clrk66")
+    initial_idx = int(not include_initial)
+    terminus_idx = int(not include_terminus)
+    lonlats = geod.npts(
+        _BOSTON_LON,
+        _BOSTON_LAT,
+        _PORTLAND_LON,
+        _PORTLAND_LAT,
+        npts=6 - initial_idx - terminus_idx,
+        initial_idx=initial_idx,
+        terminus_idx=terminus_idx,
+    )
+    expected_lonlats = [
+        (-80.797, 44.837),
+        (-91.218, 46.536),
+        (-102.106, 47.236),
+        (-113.066, 46.888),
+    ]
+    if include_initial:
+        expected_lonlats.insert(0, (_BOSTON_LON, _BOSTON_LAT))
+    if include_terminus:
+        expected_lonlats.append((_PORTLAND_LON, _PORTLAND_LAT))
+    assert_almost_equal(lonlats, expected_lonlats, decimal=3)
+
+
+@pytest.mark.parametrize(
+    "ellipsoid,expected_azi12,expected_az21,expected_dist",
+    [("clrk66", -66.531, 75.654, 4164192.708), ("WGS84", -66.530, 75.654, 4164074.239)],
+)
+def test_geodesic_inv__pickle(
+    ellipsoid, expected_azi12, expected_az21, expected_dist, tmp_path
+):
+    geod = Geod(ellps=ellipsoid)
+    az12, az21, dist = geod.inv(_BOSTON_LON, _BOSTON_LAT, _PORTLAND_LON, _PORTLAND_LAT)
+    assert_almost_equal(
+        (az12, az21, dist), (expected_azi12, expected_az21, expected_dist), decimal=3
+    )
+    pickle_file = tmp_path / "geod1.pickle"
+    with open(pickle_file, "wb") as gp1w:
+        pickle.dump(geod, gp1w, -1)
+    with open(pickle_file, "rb") as gp1:
+        geod_pickle = pickle.load(gp1)
+    pickle_az12, pickle_az21, pickle_dist = geod_pickle.inv(
+        _BOSTON_LON, _BOSTON_LAT, _PORTLAND_LON, _PORTLAND_LAT
+    )
+    assert_almost_equal(
+        (pickle_az12, pickle_az21, pickle_dist),
+        (expected_azi12, expected_az21, expected_dist),
+        decimal=3,
+    )
+
+
+def test_geodesic_inv__string_init():
+    geod = Geod("+ellps=clrk66")
+    az12, az21, dist = geod.inv(_BOSTON_LON, _BOSTON_LAT, _PORTLAND_LON, _PORTLAND_LAT)
     assert_almost_equal((az12, az21, dist), (-66.531, 75.654, 4164192.708), decimal=3)
 
 
@@ -685,8 +772,8 @@ def test_geod_fwd_radians():
     az1 = 1
     dist = 1
     assert_almost_equal(
-        np.rad2deg(g.fwd(lon1, lat1, az1, dist, radians=True)),
-        g.fwd(lon1 * 180 / np.pi, lat1 * 180 / np.pi, az1 * 180 / np.pi, dist),
+        numpy.rad2deg(g.fwd(lon1, lat1, az1, dist, radians=True)),
+        g.fwd(lon1 * 180 / numpy.pi, lat1 * 180 / numpy.pi, az1 * 180 / numpy.pi, dist),
     )
 
 
@@ -698,15 +785,15 @@ def test_geod_inv_radians():
     lat2 = 1
     # the third output is in distance, so we don't want to change from deg-rad there
     out_rad = list(g.inv(lon1, lat1, lon2, lat2, radians=True))
-    out_rad[0] *= 180 / np.pi
-    out_rad[1] *= 180 / np.pi
+    out_rad[0] *= 180 / numpy.pi
+    out_rad[1] *= 180 / numpy.pi
     assert_almost_equal(
         out_rad,
         g.inv(
-            lon1 * 180 / np.pi,
-            lat1 * 180 / np.pi,
-            lon2 * 180 / np.pi,
-            lat2 * 180 / np.pi,
+            lon1 * 180 / numpy.pi,
+            lat1 * 180 / numpy.pi,
+            lon2 * 180 / numpy.pi,
+            lat2 * 180 / numpy.pi,
         ),
     )
 
@@ -718,7 +805,7 @@ def test_geod_scalar_array(func_name, radians):
     g = Geod(ellps="clrk66")
     func = getattr(g, func_name)
     assert_almost_equal(
-        np.transpose([func(0, 0, 1, 1, radians=radians) for i in range(2)]),
+        numpy.transpose([func(0, 0, 1, 1, radians=radians) for i in range(2)]),
         func([0, 0], [0, 0], [1, 1], [1, 1], radians=radians),
     )
 
@@ -735,21 +822,23 @@ def test_geod_inv_honours_input_types(lons1, lats1, lons2):
     assert isinstance(outz, type(lons2))
 
 
-def test_geod_fwd_inv_inplace():
+def test_geodesic_fwd_inv_inplace():
     gg = Geod(ellps="clrk66")
-    lon1pt = np.array([0], dtype=np.float64)
-    lat1pt = np.array([0], dtype=np.float64)
-    lon2pt = np.array([1], dtype=np.float64)
-    lat2pt = np.array([1], dtype=np.float64)
+    _BOSTON_LON = numpy.array([0], dtype=numpy.float64)
+    _BOSTON_LAT = numpy.array([0], dtype=numpy.float64)
+    _PORTLAND_LON = numpy.array([1], dtype=numpy.float64)
+    _PORTLAND_LAT = numpy.array([1], dtype=numpy.float64)
 
-    az12, az21, dist = gg.inv(lon1pt, lat1pt, lon2pt, lat2pt, inplace=True)
-    assert az12 is lon1pt
-    assert az21 is lat1pt
-    assert dist is lon2pt
+    az12, az21, dist = gg.inv(
+        _BOSTON_LON, _BOSTON_LAT, _PORTLAND_LON, _PORTLAND_LAT, inplace=True
+    )
+    assert az12 is _BOSTON_LON
+    assert az21 is _BOSTON_LAT
+    assert dist is _PORTLAND_LON
 
-    endlon, endlat, backaz = gg.fwd(lon1pt, lat1pt, az12, dist, inplace=True)
-    assert endlon is lon1pt
-    assert endlat is lat1pt
+    endlon, endlat, backaz = gg.fwd(_BOSTON_LON, _BOSTON_LAT, az12, dist, inplace=True)
+    assert endlon is _BOSTON_LON
+    assert endlat is _BOSTON_LAT
     assert backaz is az12
 
 
@@ -772,7 +861,7 @@ def test_geod__build_kwargs(kwarg):
 @pytest.mark.parametrize("radians", [False, True])
 def test_geod__reverse_azimuth(radians):
     f = math.pi / 180 if radians else 1
-    xy = np.array(
+    xy = numpy.array(
         [
             [0, 0 + 180],
             [180, 180 - 180],


### PR DESCRIPTION
This converts the really big test into smaller tests to make the code clearer and easier to debug. This also removes the interdependence on subsections of the tests.