### PR TITLE
REF: Raise error when CRS.to_wkt, CRS.to_json, or CRS.to_proj4 returns None

### DIFF
--- a/docs/history.rst
+++ b/docs/history.rst
@@ -8,6 +8,8 @@ Latest
     Note: BREAKING CHANGE for the default value `return_back_azimuth=True` in the functions `fwd_intermediate` and `inv_intermediate`
     to mach the default value in `fwd` and `inv`
 - PERF: Optimize point transformations (pull #1204)
+- REF: Raise error when :meth:`.CRS.to_wkt`, :meth:`.CRS.to_json`, or :meth:`.CRS.to_proj4` returns None (issue #1036)
+
 
 3.4.1
 -----

--- a/pyproj/crs/crs.py
+++ b/pyproj/crs/crs.py
@@ -1226,12 +1226,9 @@ class CRS:
         """
         wkt = self._crs.to_wkt(version=version, pretty=pretty)
         if wkt is None:
-            warnings.warn(
+            raise CRSError(
                 f"CRS cannot be converted to a WKT string of a '{version}' version. "
-                "Select a different version of a WKT string or edit your CRS. Future"
-                "versions of pyproj will raise a CRSError in this case.",
-                FutureWarning,
-                stacklevel=2,
+                "Select a different version of a WKT string or edit your CRS."
             )
         return wkt
 
@@ -1254,12 +1251,7 @@ class CRS:
         """
         proj_json = self._crs.to_json(pretty=pretty, indentation=indentation)
         if proj_json is None:
-            warnings.warn(
-                "CRS cannot be converted to a PROJ JSON string. "
-                "Future versions of pyproj will raise a CRSError in this case.",
-                FutureWarning,
-                stacklevel=2,
-            )
+            raise CRSError("CRS cannot be converted to a PROJ JSON string.")
         return proj_json
 
     def to_json_dict(self) -> dict:
@@ -1295,12 +1287,7 @@ class CRS:
         """
         proj = self._crs.to_proj4(version=version)
         if proj is None:
-            warnings.warn(
-                "CRS cannot be converted to a PROJ string. "
-                "Future versions of pyproj will raise a CRSError in this case.",
-                FutureWarning,
-                stacklevel=2,
-            )
+            raise CRSError("CRS cannot be converted to a PROJ string.")
         return proj
 
     def to_epsg(self, min_confidence: int = 70) -> Optional[int]:

--- a/test/crs/test_crs.py
+++ b/test/crs/test_crs.py
@@ -939,14 +939,14 @@ def test_to_wkt_none_warning(wkt_version):
         'ORDER[3],LENGTHUNIT["metre",1,ID["EPSG",9001]]]]'
     )
     crs = CRS.from_wkt(wkt_string)
-    with pytest.warns(FutureWarning, match="CRS cannot be converted to a WKT string"):
+    with pytest.raises(CRSError, match="CRS cannot be converted to a WKT string"):
         assert crs.to_wkt(version=wkt_version) is None
 
 
 def test_to_proj4_none_warning():
     crs = CRS("EPSG:4326")
-    with patch("pyproj.crs.crs.CRS._crs") as crs_mock, pytest.warns(
-        FutureWarning, match="CRS cannot be converted to a PROJ string"
+    with patch("pyproj.crs.crs.CRS._crs") as crs_mock, pytest.raises(
+        CRSError, match="CRS cannot be converted to a PROJ string"
     ):
         crs_mock.to_proj4.return_value = None
         assert crs.to_proj4() is None
@@ -954,8 +954,8 @@ def test_to_proj4_none_warning():
 
 def test_to_json_none_warning():
     crs = CRS("EPSG:4326")
-    with patch("pyproj.crs.crs.CRS._crs") as crs_mock, pytest.warns(
-        FutureWarning, match="CRS cannot be converted to a PROJ JSON string"
+    with patch("pyproj.crs.crs.CRS._crs") as crs_mock, pytest.raises(
+        CRSError, match="CRS cannot be converted to a PROJ JSON string"
     ):
         crs_mock.to_json.return_value = None
         assert crs.to_json() is None


### PR DESCRIPTION
 - [x] Closes #1036
 - [x] Fully documented, including `history.rst` for all changes and `api/*.rst` for new API
