### PR TITLE
CLN: Remove AzumuthalEquidistantConversion & LambertAzumuthalEqualAreaConversion

### DIFF
--- a/docs/history.rst
+++ b/docs/history.rst
@@ -9,6 +9,7 @@ Latest
     to mach the default value in `fwd` and `inv`
 - PERF: Optimize point transformations (pull #1204)
 - REF: Raise error when :meth:`.CRS.to_wkt`, :meth:`.CRS.to_json`, or :meth:`.CRS.to_proj4` returns None (issue #1036)
+- CLN: Remove `AzumuthalEquidistantConversion` & :class:`LambertAzumuthalEqualAreaConversion`. :class:`AzimuthalEquidistantConversion` & :class:`LambertAzimuthalEqualAreaConversion` should be used instead (pull #1219)
 
 
 3.4.1

--- a/pyproj/crs/coordinate_operation.py
+++ b/pyproj/crs/coordinate_operation.py
@@ -173,36 +173,6 @@ class AzimuthalEquidistantConversion(CoordinateOperation):
         return cls.from_json_dict(aeqd_json)
 
 
-class AzumuthalEquidistantConversion(AzimuthalEquidistantConversion):
-    """
-    For backwards compatibility.
-
-    .. versionadded:: 2.5.0
-    .. deprecated:: 3.2.0
-    """
-
-    def __new__(
-        cls,
-        latitude_natural_origin: float = 0.0,
-        longitude_natural_origin: float = 0.0,
-        false_easting: float = 0.0,
-        false_northing: float = 0.0,
-    ):
-        warnings.warn(
-            "AzumuthalEquidistantConversion is deprecated. "
-            "Please use AzimuthalEquidistantConversion.",
-            FutureWarning,
-            stacklevel=2,
-        )
-        return AzimuthalEquidistantConversion.__new__(
-            AzimuthalEquidistantConversion,
-            latitude_natural_origin=latitude_natural_origin,
-            longitude_natural_origin=longitude_natural_origin,
-            false_easting=false_easting,
-            false_northing=false_northing,
-        )
-
-
 class GeostationarySatelliteConversion(CoordinateOperation):
     """
     .. versionadded:: 2.5.0
@@ -356,36 +326,6 @@ class LambertAzimuthalEqualAreaConversion(CoordinateOperation):
             ],
         }
         return cls.from_json_dict(laea_json)
-
-
-class LambertAzumuthalEqualAreaConversion(LambertAzimuthalEqualAreaConversion):
-    """
-    For backwards compatibility.
-
-    .. versionadded:: 2.5.0
-    .. deprecated:: 3.2.0
-    """
-
-    def __new__(
-        cls,
-        latitude_natural_origin: float = 0.0,
-        longitude_natural_origin: float = 0.0,
-        false_easting: float = 0.0,
-        false_northing: float = 0.0,
-    ):
-        warnings.warn(
-            "LambertAzumuthalEqualAreaConversion is deprecated. "
-            "Please use LambertAzimuthalEqualAreaConversion.",
-            FutureWarning,
-            stacklevel=2,
-        )
-        return LambertAzimuthalEqualAreaConversion.__new__(
-            LambertAzimuthalEqualAreaConversion,
-            latitude_natural_origin=latitude_natural_origin,
-            longitude_natural_origin=longitude_natural_origin,
-            false_easting=false_easting,
-            false_northing=false_northing,
-        )
 
 
 class LambertConformalConic2SPConversion(CoordinateOperation):

--- a/test/crs/test_crs_coordinate_operation.py
+++ b/test/crs/test_crs_coordinate_operation.py
@@ -5,12 +5,10 @@ from pyproj.crs import GeographicCRS
 from pyproj.crs.coordinate_operation import (
     AlbersEqualAreaConversion,
     AzimuthalEquidistantConversion,
-    AzumuthalEquidistantConversion,
     EquidistantCylindricalConversion,
     GeostationarySatelliteConversion,
     HotineObliqueMercatorBConversion,
     LambertAzimuthalEqualAreaConversion,
-    LambertAzumuthalEqualAreaConversion,
     LambertConformalConic1SPConversion,
     LambertConformalConic2SPConversion,
     LambertCylindricalEqualAreaConversion,
@@ -74,19 +72,6 @@ def test_albers_equal_area_operation():
         "Latitude of false origin": 3.0,
         "Longitude of false origin": 4.0,
         "Northing at false origin": 6.0,
-    }
-
-
-def test_azumuthal_equidistant_operation__defaults():
-    with pytest.warns(FutureWarning, match="deprecated"):
-        aeop = AzumuthalEquidistantConversion()
-    assert aeop.name == "unknown"
-    assert aeop.method_name == "Modified Azimuthal Equidistant"
-    assert _to_dict(aeop) == {
-        "Latitude of natural origin": 0.0,
-        "Longitude of natural origin": 0.0,
-        "False easting": 0.0,
-        "False northing": 0.0,
     }
 
 
@@ -156,19 +141,6 @@ def test_geostationary_operation():
 def test_geostationary_operation__invalid_sweep():
     with pytest.raises(CRSError):
         GeostationarySatelliteConversion(sweep_angle_axis="P", satellite_height=10)
-
-
-def test_lambert_azumuthal_equal_area_operation__defaults():
-    with pytest.warns(FutureWarning, match="deprecated"):
-        aeop = LambertAzumuthalEqualAreaConversion()
-    assert aeop.name == "unknown"
-    assert aeop.method_name == "Lambert Azimuthal Equal Area"
-    assert _to_dict(aeop) == {
-        "Latitude of natural origin": 0.0,
-        "Longitude of natural origin": 0.0,
-        "False easting": 0.0,
-        "False northing": 0.0,
-    }
 
 
 def test_lambert_azimuthal_equal_area_operation__defaults():


### PR DESCRIPTION
Related: #882

AzimuthalEquidistantConversion & LambertAzimuthalEqualAreaConversion should be used instead.