### PR TITLE
geod.inv - support for mixed scalar and vector inputs and output selection

### DIFF
--- a/pyproj/_geod.pyi
+++ b/pyproj/_geod.pyi
@@ -46,6 +46,9 @@ class Geod:
         lats1: Any,
         lons2: Any,
         lats2: Any,
+        pazi1_out: int,
+        pazi2_out: int,
+        ps12_out: int,
         radians: bool = False,
         return_back_azimuth: bool = False,
     ) -> None: ...

--- a/test/test_geod.py
+++ b/test/test_geod.py
@@ -39,6 +39,7 @@ _PORTLAND_LON = -123.0 - (41.0 / 60.0)
 
 
 @pytest.mark.parametrize("return_back_azimuth", [True, False])
+@pytest.mark.parametrize("return_az2", [True, False])
 @pytest.mark.parametrize(
     "ellipsoid,true_az12,true_az21,expected_distance",
     [
@@ -52,18 +53,24 @@ def test_geodesic_inv(
     true_az21,
     expected_distance,
     return_back_azimuth,
+    return_az2,
     scalar_and_array,
 ):
     geod = Geod(ellps=ellipsoid)
+    output_map = None if return_az2 else [True, False, True]
     az12, az21, dist = geod.inv(
         scalar_and_array(_BOSTON_LON),
         scalar_and_array(_BOSTON_LAT),
         scalar_and_array(_PORTLAND_LON),
         scalar_and_array(_PORTLAND_LAT),
         return_back_azimuth=return_back_azimuth,
+        output_map=output_map,
     )
-    if not return_back_azimuth:
-        az21 = reverse_azimuth(az21)
+    if return_az2:
+        if not return_back_azimuth:
+            az21 = reverse_azimuth(az21)
+    else:
+        true_az21 = None
     assert_almost_equal(
         (az12, az21, dist),
         (


### PR DESCRIPTION
This PR is (trying) to add the option to call `inv` with vectors that are the same length or with length=1 (for example, from (lon1, lat1) to [(lon2, lon3), (lat2, lat3)] and also to select which outputs to return (for example only azi1 and dist)