### PR TITLE
ENH: Added `allow_superseded` kwargs to `TransformerGroup`

### DIFF
--- a/docs/history.rst
+++ b/docs/history.rst
@@ -3,7 +3,7 @@ Change Log
 
 Latest
 ------
-- ENH: Added allow_superseded kwargs to :class:`pyproj.transformer.Transformer` and :class:`pyproj.transformer.TransformerGroup` (pull #1269)
+- ENH: Added allow_superseded kwargs to :class:`pyproj.transformer.TransformerGroup` (pull #1269)
 
 3.5.0
 ------

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -3,6 +3,7 @@ Change Log
 
 Latest
 ------
+- ENH: Added allow_superseded kwargs to :class:`pyproj.transformer.Transformer` and :class:`pyproj.transformer.TransformerGroup` (pull #1269)
 
 3.5.0
 ------

--- a/pyproj/_transformer.pyi
+++ b/pyproj/_transformer.pyi
@@ -41,6 +41,7 @@ class _TransformerGroup:
         authority: Optional[str],
         accuracy: Optional[float],
         allow_ballpark: bool,
+        allow_superseded: bool,
     ) -> None: ...
 
 class _Transformer(Base):
@@ -85,6 +86,7 @@ class _Transformer(Base):
         allow_ballpark: Optional[bool] = None,
         force_over: bool = False,
         only_best: Optional[bool] = None,
+        allow_superseded: bool = False,
     ) -> "_Transformer": ...
     @staticmethod
     def from_pipeline(proj_pipeline: bytes) -> "_Transformer": ...

--- a/pyproj/_transformer.pyi
+++ b/pyproj/_transformer.pyi
@@ -86,7 +86,6 @@ class _Transformer(Base):
         allow_ballpark: Optional[bool] = None,
         force_over: bool = False,
         only_best: Optional[bool] = None,
-        allow_superseded: bool = False,
     ) -> "_Transformer": ...
     @staticmethod
     def from_pipeline(proj_pipeline: bytes) -> "_Transformer": ...

--- a/pyproj/_transformer.pyx
+++ b/pyproj/_transformer.pyx
@@ -141,6 +141,7 @@ cdef class _TransformerGroup:
         bint allow_ballpark,
         str authority,
         double accuracy,
+        bint allow_superseded,
     ):
         """
         From PROJ docs:
@@ -201,6 +202,11 @@ cdef class _TransformerGroup:
                 self.context,
                 operation_factory_context,
                 allow_ballpark,
+            )
+            proj_operation_factory_context_set_discard_superseded(
+                self.context,
+                operation_factory_context,
+                not allow_superseded,
             )
             proj_operation_factory_context_set_grid_availability_use(
                 self.context,
@@ -268,6 +274,7 @@ cdef PJ* proj_create_crs_to_crs(
     allow_ballpark,
     bint force_over,
     only_best,
+    allow_superseded,
 ) except NULL:
     """
     This is the same as proj_create_crs_to_crs in proj.h
@@ -527,6 +534,7 @@ cdef class _Transformer(Base):
         allow_ballpark=None,
         bint force_over=False,
         only_best=None,
+        allow_superseded=False,
     ):
         """
         Create a transformer from CRS objects
@@ -569,6 +577,7 @@ cdef class _Transformer(Base):
                 allow_ballpark=allow_ballpark,
                 force_over=force_over,
                 only_best=only_best,
+                allow_superseded=allow_superseded,
             )
         finally:
             if pj_area_of_interest != NULL:

--- a/pyproj/_transformer.pyx
+++ b/pyproj/_transformer.pyx
@@ -274,7 +274,6 @@ cdef PJ* proj_create_crs_to_crs(
     allow_ballpark,
     bint force_over,
     only_best,
-    allow_superseded,
 ) except NULL:
     """
     This is the same as proj_create_crs_to_crs in proj.h
@@ -534,7 +533,6 @@ cdef class _Transformer(Base):
         allow_ballpark=None,
         bint force_over=False,
         only_best=None,
-        allow_superseded=False,
     ):
         """
         Create a transformer from CRS objects
@@ -577,7 +575,6 @@ cdef class _Transformer(Base):
                 allow_ballpark=allow_ballpark,
                 force_over=force_over,
                 only_best=only_best,
-                allow_superseded=allow_superseded,
             )
         finally:
             if pj_area_of_interest != NULL:

--- a/pyproj/proj.pxi
+++ b/pyproj/proj.pxi
@@ -478,6 +478,11 @@ cdef extern from "proj.h" nogil:
         PJ_OPERATION_FACTORY_CONTEXT *factory_ctx,
         int allow
     )
+    void proj_operation_factory_context_set_discard_superseded(
+        PJ_CONTEXT *ctx,
+        PJ_OPERATION_FACTORY_CONTEXT *factory_ctx,
+        int discard
+    )
     void proj_operation_factory_context_set_desired_accuracy(
         PJ_CONTEXT *ctx,
         PJ_OPERATION_FACTORY_CONTEXT *factory_ctx,

--- a/pyproj/transformer.py
+++ b/pyproj/transformer.py
@@ -94,7 +94,6 @@ class TransformerFromCRS(  # pylint: disable=too-many-instance-attributes
     allow_ballpark: Optional[bool]
     force_over: bool = False
     only_best: Optional[bool] = None
-    allow_superseded: bool = False
 
     def __call__(self) -> _Transformer:
         """
@@ -112,7 +111,6 @@ class TransformerFromCRS(  # pylint: disable=too-many-instance-attributes
             allow_ballpark=self.allow_ballpark,
             force_over=self.force_over,
             only_best=self.only_best,
-            allow_superseded=self.allow_superseded,
         )
 
 
@@ -561,7 +559,6 @@ class Transformer:
         allow_ballpark: Optional[bool] = None,
         force_over: bool = False,
         only_best: Optional[bool] = None,
-        allow_superseded: bool = False,
     ) -> "Transformer":
         """Make a Transformer from a :obj:`pyproj.crs.CRS` or input used to create one.
 
@@ -575,7 +572,6 @@ class Transformer:
         .. versionadded:: 3.1.0 authority, accuracy, allow_ballpark
         .. versionadded:: 3.4.0 force_over
         .. versionadded:: 3.5.0 only_best
-        .. versionadded:: 3.6.0 allow_superseded
 
         Parameters
         ----------
@@ -619,10 +615,6 @@ class Transformer:
             ``only_best_default`` setting of :ref:`proj-ini`.
             The only_best kwarg overrides the default value if set.
             Requires PROJ 9.2+.
-        allow_superseded: bool, default=False
-            Set to True to allow the use of superseded (but not deprecated)
-            transformations in the candidate coordinate operations. Default is
-            to disallow.
 
         Returns
         -------
@@ -640,7 +632,6 @@ class Transformer:
                 allow_ballpark=allow_ballpark,
                 force_over=force_over,
                 only_best=only_best,
-                allow_superseded=allow_superseded,
             )
         )
 

--- a/pyproj/transformer.py
+++ b/pyproj/transformer.py
@@ -94,6 +94,7 @@ class TransformerFromCRS(  # pylint: disable=too-many-instance-attributes
     allow_ballpark: Optional[bool]
     force_over: bool = False
     only_best: Optional[bool] = None
+    allow_superseded: bool = False
 
     def __call__(self) -> _Transformer:
         """
@@ -111,6 +112,7 @@ class TransformerFromCRS(  # pylint: disable=too-many-instance-attributes
             allow_ballpark=self.allow_ballpark,
             force_over=self.force_over,
             only_best=self.only_best,
+            allow_superseded=self.allow_superseded,
         )
 
 
@@ -161,11 +163,13 @@ class TransformerGroup(_TransformerGroup):
         authority: Optional[str] = None,
         accuracy: Optional[float] = None,
         allow_ballpark: bool = True,
+        allow_superseded: bool = False,
     ) -> None:
         """Get all possible transformations from a :obj:`pyproj.crs.CRS`
         or input used to create one.
 
         .. versionadded:: 3.4.0 authority, accuracy, allow_ballpark
+        .. versionadded:: 3.6.0 allow_superseded
 
         Parameters
         ----------
@@ -195,6 +199,10 @@ class TransformerGroup(_TransformerGroup):
         allow_ballpark: bool, default=True
             Set to False to disallow the use of Ballpark transformation
             in the candidate coordinate operations. Default is to allow.
+        allow_superseded: bool, default=False
+            Set to True to allow the use of superseded (but not deprecated)
+            transformations in the candidate coordinate operations. Default is
+            to disallow.
 
         """
         super().__init__(
@@ -205,6 +213,7 @@ class TransformerGroup(_TransformerGroup):
             authority=authority,
             accuracy=-1 if accuracy is None else accuracy,
             allow_ballpark=allow_ballpark,
+            allow_superseded=allow_superseded,
         )
         for iii, transformer in enumerate(self._transformers):
             # pylint: disable=unsupported-assignment-operation
@@ -552,6 +561,7 @@ class Transformer:
         allow_ballpark: Optional[bool] = None,
         force_over: bool = False,
         only_best: Optional[bool] = None,
+        allow_superseded: bool = False,
     ) -> "Transformer":
         """Make a Transformer from a :obj:`pyproj.crs.CRS` or input used to create one.
 
@@ -565,6 +575,7 @@ class Transformer:
         .. versionadded:: 3.1.0 authority, accuracy, allow_ballpark
         .. versionadded:: 3.4.0 force_over
         .. versionadded:: 3.5.0 only_best
+        .. versionadded:: 3.6.0 allow_superseded
 
         Parameters
         ----------
@@ -608,6 +619,10 @@ class Transformer:
             ``only_best_default`` setting of :ref:`proj-ini`.
             The only_best kwarg overrides the default value if set.
             Requires PROJ 9.2+.
+        allow_superseded: bool, default=False
+            Set to True to allow the use of superseded (but not deprecated)
+            transformations in the candidate coordinate operations. Default is
+            to disallow.
 
         Returns
         -------
@@ -625,6 +640,7 @@ class Transformer:
                 allow_ballpark=allow_ballpark,
                 force_over=force_over,
                 only_best=only_best,
+                allow_superseded=allow_superseded,
             )
         )
 

--- a/test/test_transformer.py
+++ b/test/test_transformer.py
@@ -1191,13 +1191,6 @@ def test_transformer_authority_filter():
 
 
 @pytest.mark.parametrize(
-    "allow_superseded", [(True,), (False,), (123456789,), ("blah",)]
-)
-def test_transformer_allow_superseded(allow_superseded):
-    Transformer.from_crs(6319, "EPSG:4326+5703", allow_superseded=allow_superseded)
-
-
-@pytest.mark.parametrize(
     "input_string",
     [
         "EPSG:1671",

--- a/test/test_transformer.py
+++ b/test/test_transformer.py
@@ -1191,6 +1191,13 @@ def test_transformer_authority_filter():
 
 
 @pytest.mark.parametrize(
+    "allow_superseded", [(True,), (False,), (123456789,), ("blah",)]
+)
+def test_transformer_allow_superseded(allow_superseded):
+    Transformer.from_crs(6319, "EPSG:4326+5703", allow_superseded=allow_superseded)
+
+
+@pytest.mark.parametrize(
     "input_string",
     [
         "EPSG:1671",
@@ -1649,6 +1656,23 @@ def test_transformer_group_allow_ballpark_filter():
     )
     assert not group.transformers
     assert not group.unavailable_operations
+
+
+@pytest.mark.parametrize(
+    "from_crs, to_crs, allow_superseded, expected_num_transformers",
+    [
+        (6319, 5703, 0, 2),
+        (6319, 5703, False, 2),
+        (6319, 5703, True, 3),
+        (6319, 5703, 123456789, 3),
+        (6319, 5703, "blah", 3),
+    ],
+)
+def test_transformer_group_allow_superseded_filter(
+    from_crs, to_crs, allow_superseded, expected_num_transformers
+):
+    group = TransformerGroup(from_crs, to_crs, allow_superseded=allow_superseded)
+    assert len(group.transformers) == expected_num_transformers
 
 
 def test_transformer_group_authority_filter():


### PR DESCRIPTION
 - [x] Closes #1261 
 - [x] Tests added
 - [x] Fully documented, including `history.rst` for all changes and `api/*.rst` for new API
