### PR TITLE
DOC: Add a reference to #1206 in history

### DIFF
--- a/docs/history.rst
+++ b/docs/history.rst
@@ -19,6 +19,7 @@ Latest
     to mach the default value in `fwd` and `inv`
 - ENH: Added only_best kwarg to :meth:`.Transformer.from_crs` (issue #1228)
 - PERF: Optimize point transformations (pull #1204)
+- PERF: Optimize for single point in Geod fwd/inv functions (pull #1206)
 - REF: Raise error when :meth:`.CRS.to_wkt`, :meth:`.CRS.to_json`, or :meth:`.CRS.to_proj4` returns None (issue #1036)
 - CLN: Remove `AzumuthalEquidistantConversion` & :class:`LambertAzumuthalEqualAreaConversion`. :class:`AzimuthalEquidistantConversion` & :class:`LambertAzimuthalEqualAreaConversion` should be used instead (pull #1219)
 - BUG: Fix Derived Projected CRS support (issue #1182)


### PR DESCRIPTION
I think that this is missing from: https://github.com/pyproj4/pyproj/pull/1206

 - [X] Fully documented, including `history.rst` for all changes and `api/*.rst` for new API
