### PR TITLE
Fix logo view on Pypi

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![Pyproj logo](docs/media/logo.png)
+![Pyproj logo](https://raw.githubusercontent.com/pyproj4/pyproj/main/docs/media/logo.png)
 
 # pyproj
 


### PR DESCRIPTION
Fixe to allow for the logo to be visible on the top of the README.md in [Pypi](https://pypi.org/project/pyproj/) by referencing the logo directly, not relative references
![image](https://github.com/pyproj4/pyproj/assets/22159116/5f874421-2460-4733-b285-c2ecabe8d81f)
