### PR TITLE
DOC: Spelling permimeter -> perimeter

### DIFF
--- a/pyproj/_geod.pyx
+++ b/pyproj/_geod.pyx
@@ -566,7 +566,7 @@ cdef class Geod:
         Returns
         -------
         (float, float):
-            The area (meter^2) and permimeter (meters) of the polygon.
+            The area (meter^2) and perimeter (meters) of the polygon.
 
         """
         cdef PyBuffWriteManager lonbuff = PyBuffWriteManager(lons)

--- a/pyproj/geod.py
+++ b/pyproj/geod.py
@@ -969,7 +969,7 @@ class Geod(_Geod):
         Returns
         -------
         (float, float):
-            The geodesic area (meters^2) and permimeter (meters) of the polygon.
+            The geodesic area (meters^2) and perimeter (meters) of the polygon.
         """
         return self._polygon_area_perimeter(
             _copytobuffer(lons)[0], _copytobuffer(lats)[0], radians=radians
@@ -1077,7 +1077,7 @@ class Geod(_Geod):
         Returns
         -------
         (float, float):
-            The geodesic area (meters^2) and permimeter (meters) of the polygon.
+            The geodesic area (meters^2) and perimeter (meters) of the polygon.
         """
         try:
             return self.polygon_area_perimeter(  # type: ignore


### PR DESCRIPTION
"permimeter" -> "perimeter" 
