### PR TITLE
Cache PROJ library build when building wheels

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -116,6 +116,12 @@ jobs:
           mkdir -p ${GITHUB_WORKSPACE}/pyproj/proj_dir/share/proj
           cp "$VCPKG_INSTALLATION_ROOT/installed/${{ matrix.triplet }}/share/proj/"* ${GITHUB_WORKSPACE}/pyproj/proj_dir/share/proj/
 
+      - name: Cache PROJ build
+        uses: actions/cache@v3
+        with:
+          path: ${{ runner.temp }}/proj-${{ env.PROJ_VERSION }}
+          key: ${{ matrix.os }}-${{ matrix.arch }}-${{ env.PROJ_VERSION }}-${{ hashFiles('ci/proj-compile-wheels.sh') }}
+
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.16
         env:
@@ -125,11 +131,13 @@ jobs:
             PROJ_WHEEL=true
             PROJ_NETWORK=ON
             PROJ_VERSION=${{ env.PROJ_VERSION }}
+            PROJ_CACHE=/host${{ runner.temp }}/proj=${{ env.PROJ_VERSION }}/
             PROJ_DIR=/project/pyproj/proj_dir
           CIBW_ENVIRONMENT_MACOS:
             PROJ_WHEEL=true
             PROJ_NETWORK=ON
             PROJ_VERSION=${{ env.PROJ_VERSION }}
+            PROJ_CACHE=/host${{ runner.temp }}/proj=${{ env.PROJ_VERSION }}/
             PROJ_DIR=${GITHUB_WORKSPACE}/pyproj/proj_dir
             MACOSX_DEPLOYMENT_TARGET=10.9
             CMAKE_OSX_ARCHITECTURES='${{ matrix.cmake_osx_architectures }}'
@@ -138,6 +146,7 @@ jobs:
             PROJ_WHEEL=true
             PROJ_NETWORK=ON
             PROJ_VERSION=${{ env.PROJ_VERSION }}
+            PROJ_CACHE=/host${{ runner.temp }}/proj=${{ env.PROJ_VERSION }}/
             PROJ_DIR=$VCPKG_INSTALLATION_ROOT/installed/${{ matrix.triplet }}
           CIBW_BEFORE_BUILD_WINDOWS: "python -m pip install delvewheel"
           CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: "delvewheel repair --add-path C:/vcpkg/installed/${{ matrix.triplet }}/bin -w {dest_dir} {wheel}"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -121,7 +121,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ${{ runner.temp }}/proj-${{ env.PROJ_VERSION }}
-          key: ${{ matrix.os }}-${{ matrix.arch }}-${{ env.PROJ_VERSION }}-${{ hashFiles('ci/proj-compile-wheels.sh') }}
+          key: ${{ matrix.os }}-${{ matrix.arch }}-${{ env.PROJ_VERSION }}-${{ hashFiles('ci/proj-compile-wheels.sh') }}-cache0
 
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.16

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -152,6 +152,8 @@ jobs:
             PROJ_DIR=$VCPKG_INSTALLATION_ROOT/installed/${{ matrix.triplet }}
           CIBW_BEFORE_BUILD_WINDOWS: "python -m pip install delvewheel"
           CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: "delvewheel repair --add-path C:/vcpkg/installed/${{ matrix.triplet }}/bin -w {dest_dir} {wheel}"
+          # debug:
+          CIBW_REPAIR_WHEEL_COMMAND_LINUX: "bash -c \"echo $LD_LIBRARY_PATH; auditwheel repair -w {dest_dir} {wheel}\""
           CIBW_BEFORE_ALL_LINUX: bash ./ci/proj-compile-wheels.sh
           CIBW_BEFORE_ALL_MACOS: bash ./ci/proj-compile-wheels.sh
           CIBW_TEST_REQUIRES: cython pytest numpy --config-settings=setup-args="-Dallow-noblas=true"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -152,9 +152,6 @@ jobs:
             PROJ_DIR=$VCPKG_INSTALLATION_ROOT/installed/${{ matrix.triplet }}
           CIBW_BEFORE_BUILD_WINDOWS: "python -m pip install delvewheel"
           CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: "delvewheel repair --add-path C:/vcpkg/installed/${{ matrix.triplet }}/bin -w {dest_dir} {wheel}"
-          # debug:
-          CIBW_REPAIR_WHEEL_COMMAND_LINUX: >-
-              export LD_LIBRARY_PATH="/host${{ runner.temp }}/proj-${{ env.PROJ_VERSION }}/proj-deps/lib:$LD_LIBRARY_PATH"; echo $LD_LIBRARY_PATH; auditwheel repair -w {dest_dir} {wheel}
           CIBW_BEFORE_ALL_LINUX: bash ./ci/proj-compile-wheels.sh
           CIBW_BEFORE_ALL_MACOS: bash ./ci/proj-compile-wheels.sh
           CIBW_TEST_REQUIRES: cython pytest numpy --config-settings=setup-args="-Dallow-noblas=true"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -153,7 +153,8 @@ jobs:
           CIBW_BEFORE_BUILD_WINDOWS: "python -m pip install delvewheel"
           CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: "delvewheel repair --add-path C:/vcpkg/installed/${{ matrix.triplet }}/bin -w {dest_dir} {wheel}"
           # debug:
-          CIBW_REPAIR_WHEEL_COMMAND_LINUX: "bash -c \"export LD_LIBRARY_PATH=\"${{ runner.temp }}/proj-${{ env.PROJ_VERSION }}/proj-deps:$LD_LIBRARY_PATH\"; echo $LD_LIBRARY_PATH; auditwheel repair -w {dest_dir} {wheel}\""
+          CIBW_REPAIR_WHEEL_COMMAND_LINUX: >-
+              bash -c "export LD_LIBRARY_PATH=\"${{ runner.temp }}/proj-${{ env.PROJ_VERSION }}/proj-deps:$LD_LIBRARY_PATH\"; echo $LD_LIBRARY_PATH; auditwheel repair -w {dest_dir} {wheel}"
           CIBW_BEFORE_ALL_LINUX: bash ./ci/proj-compile-wheels.sh
           CIBW_BEFORE_ALL_MACOS: bash ./ci/proj-compile-wheels.sh
           CIBW_TEST_REQUIRES: cython pytest numpy --config-settings=setup-args="-Dallow-noblas=true"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -154,7 +154,7 @@ jobs:
           CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: "delvewheel repair --add-path C:/vcpkg/installed/${{ matrix.triplet }}/bin -w {dest_dir} {wheel}"
           # debug:
           CIBW_REPAIR_WHEEL_COMMAND_LINUX: >-
-              export LD_LIBRARY_PATH="${{ runner.temp }}/proj-${{ env.PROJ_VERSION }}/proj-deps/lib:$LD_LIBRARY_PATH"; echo $LD_LIBRARY_PATH; auditwheel repair -w {dest_dir} {wheel}
+              export LD_LIBRARY_PATH="${{ runner.temp }}/proj-${{ env.PROJ_VERSION }}/proj-deps/lib64:$LD_LIBRARY_PATH"; echo $LD_LIBRARY_PATH; auditwheel repair -w {dest_dir} {wheel}
           CIBW_BEFORE_ALL_LINUX: bash ./ci/proj-compile-wheels.sh
           CIBW_BEFORE_ALL_MACOS: bash ./ci/proj-compile-wheels.sh
           CIBW_TEST_REQUIRES: cython pytest numpy --config-settings=setup-args="-Dallow-noblas=true"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -132,13 +132,15 @@ jobs:
             PROJ_WHEEL=true
             PROJ_NETWORK=ON
             PROJ_VERSION=${{ env.PROJ_VERSION }}
-            PROJ_CACHE=/host${{ runner.temp }}/proj-${{ env.PROJ_VERSION }}/
+            PROJ_CACHE=/host${{ runner.temp }}/proj-${{ env.PROJ_VERSION }}/proj
+            BUILD_PREFIX=/host${{ runner.temp }}/proj-${{ env.PROJ_VERSION }}/proj-deps
             PROJ_DIR=/project/pyproj/proj_dir
           CIBW_ENVIRONMENT_MACOS:
             PROJ_WHEEL=true
             PROJ_NETWORK=ON
             PROJ_VERSION=${{ env.PROJ_VERSION }}
-            PROJ_CACHE=${{ runner.temp }}/proj-${{ env.PROJ_VERSION }}/
+            PROJ_CACHE=${{ runner.temp }}/proj-${{ env.PROJ_VERSION }}/proj
+            BUILD_PREFIX=${{ runner.temp }}/proj-${{ env.PROJ_VERSION }}/proj-deps
             PROJ_DIR=${GITHUB_WORKSPACE}/pyproj/proj_dir
             MACOSX_DEPLOYMENT_TARGET=10.9
             CMAKE_OSX_ARCHITECTURES='${{ matrix.cmake_osx_architectures }}'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -135,6 +135,7 @@ jobs:
             PROJ_CACHE=/host${{ runner.temp }}/proj-${{ env.PROJ_VERSION }}/proj
             BUILD_PREFIX=/host${{ runner.temp }}/proj-${{ env.PROJ_VERSION }}/proj-deps
             PROJ_DIR=/project/pyproj/proj_dir
+            LDFLAGS="${LDFLAGS} -Wl,-rpath,/host${{ runner.temp }}/proj-${{ env.PROJ_VERSION }}/proj-deps/lib"
           CIBW_ENVIRONMENT_MACOS:
             PROJ_WHEEL=true
             PROJ_NETWORK=ON

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -117,6 +117,7 @@ jobs:
           cp "$VCPKG_INSTALLATION_ROOT/installed/${{ matrix.triplet }}/share/proj/"* ${GITHUB_WORKSPACE}/pyproj/proj_dir/share/proj/
 
       - name: Cache PROJ build
+        if: ${{ !contains(matrix.os, 'windows') }}
         uses: actions/cache@v3
         with:
           path: ${{ runner.temp }}/proj-${{ env.PROJ_VERSION }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -154,7 +154,7 @@ jobs:
           CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: "delvewheel repair --add-path C:/vcpkg/installed/${{ matrix.triplet }}/bin -w {dest_dir} {wheel}"
           # debug:
           CIBW_REPAIR_WHEEL_COMMAND_LINUX: >-
-              export LD_LIBRARY_PATH="${{ runner.temp }}/proj-${{ env.PROJ_VERSION }}/proj-deps/lib64:$LD_LIBRARY_PATH"; echo $LD_LIBRARY_PATH; auditwheel repair -w {dest_dir} {wheel}
+              export LD_LIBRARY_PATH="/host${{ runner.temp }}/proj-${{ env.PROJ_VERSION }}/proj-deps/lib:$LD_LIBRARY_PATH"; echo $LD_LIBRARY_PATH; auditwheel repair -w {dest_dir} {wheel}
           CIBW_BEFORE_ALL_LINUX: bash ./ci/proj-compile-wheels.sh
           CIBW_BEFORE_ALL_MACOS: bash ./ci/proj-compile-wheels.sh
           CIBW_TEST_REQUIRES: cython pytest numpy --config-settings=setup-args="-Dallow-noblas=true"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -154,7 +154,7 @@ jobs:
           CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: "delvewheel repair --add-path C:/vcpkg/installed/${{ matrix.triplet }}/bin -w {dest_dir} {wheel}"
           # debug:
           CIBW_REPAIR_WHEEL_COMMAND_LINUX: >-
-              bash -c "export LD_LIBRARY_PATH=\"${{ runner.temp }}/proj-${{ env.PROJ_VERSION }}/proj-deps:$LD_LIBRARY_PATH\"; echo $LD_LIBRARY_PATH; auditwheel repair -w {dest_dir} {wheel}"
+              export LD_LIBRARY_PATH="${{ runner.temp }}/proj-${{ env.PROJ_VERSION }}/proj-deps:$LD_LIBRARY_PATH"; echo $LD_LIBRARY_PATH; auditwheel repair -w {dest_dir} {wheel}
           CIBW_BEFORE_ALL_LINUX: bash ./ci/proj-compile-wheels.sh
           CIBW_BEFORE_ALL_MACOS: bash ./ci/proj-compile-wheels.sh
           CIBW_TEST_REQUIRES: cython pytest numpy --config-settings=setup-args="-Dallow-noblas=true"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -154,7 +154,7 @@ jobs:
           CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: "delvewheel repair --add-path C:/vcpkg/installed/${{ matrix.triplet }}/bin -w {dest_dir} {wheel}"
           # debug:
           CIBW_REPAIR_WHEEL_COMMAND_LINUX: >-
-              export LD_LIBRARY_PATH="${{ runner.temp }}/proj-${{ env.PROJ_VERSION }}/proj-deps:$LD_LIBRARY_PATH"; echo $LD_LIBRARY_PATH; auditwheel repair -w {dest_dir} {wheel}
+              export LD_LIBRARY_PATH="${{ runner.temp }}/proj-${{ env.PROJ_VERSION }}/proj-deps/lib:$LD_LIBRARY_PATH"; echo $LD_LIBRARY_PATH; auditwheel repair -w {dest_dir} {wheel}
           CIBW_BEFORE_ALL_LINUX: bash ./ci/proj-compile-wheels.sh
           CIBW_BEFORE_ALL_MACOS: bash ./ci/proj-compile-wheels.sh
           CIBW_TEST_REQUIRES: cython pytest numpy --config-settings=setup-args="-Dallow-noblas=true"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -153,7 +153,7 @@ jobs:
           CIBW_BEFORE_BUILD_WINDOWS: "python -m pip install delvewheel"
           CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: "delvewheel repair --add-path C:/vcpkg/installed/${{ matrix.triplet }}/bin -w {dest_dir} {wheel}"
           # debug:
-          CIBW_REPAIR_WHEEL_COMMAND_LINUX: "bash -c \"echo $LD_LIBRARY_PATH; auditwheel repair -w {dest_dir} {wheel}\""
+          CIBW_REPAIR_WHEEL_COMMAND_LINUX: "bash -c \"export LD_LIBRARY_PATH=\"${{ runner.temp }}/proj-${{ env.PROJ_VERSION }}/proj-deps:$LD_LIBRARY_PATH\"; echo $LD_LIBRARY_PATH; auditwheel repair -w {dest_dir} {wheel}\""
           CIBW_BEFORE_ALL_LINUX: bash ./ci/proj-compile-wheels.sh
           CIBW_BEFORE_ALL_MACOS: bash ./ci/proj-compile-wheels.sh
           CIBW_TEST_REQUIRES: cython pytest numpy --config-settings=setup-args="-Dallow-noblas=true"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -131,13 +131,13 @@ jobs:
             PROJ_WHEEL=true
             PROJ_NETWORK=ON
             PROJ_VERSION=${{ env.PROJ_VERSION }}
-            PROJ_CACHE=/host${{ runner.temp }}/proj=${{ env.PROJ_VERSION }}/
+            PROJ_CACHE=/host${{ runner.temp }}/proj-${{ env.PROJ_VERSION }}/
             PROJ_DIR=/project/pyproj/proj_dir
           CIBW_ENVIRONMENT_MACOS:
             PROJ_WHEEL=true
             PROJ_NETWORK=ON
             PROJ_VERSION=${{ env.PROJ_VERSION }}
-            PROJ_CACHE=/host${{ runner.temp }}/proj=${{ env.PROJ_VERSION }}/
+            PROJ_CACHE=${{ runner.temp }}/proj-${{ env.PROJ_VERSION }}/
             PROJ_DIR=${GITHUB_WORKSPACE}/pyproj/proj_dir
             MACOSX_DEPLOYMENT_TARGET=10.9
             CMAKE_OSX_ARCHITECTURES='${{ matrix.cmake_osx_architectures }}'
@@ -146,7 +146,6 @@ jobs:
             PROJ_WHEEL=true
             PROJ_NETWORK=ON
             PROJ_VERSION=${{ env.PROJ_VERSION }}
-            PROJ_CACHE=/host${{ runner.temp }}/proj=${{ env.PROJ_VERSION }}/
             PROJ_DIR=$VCPKG_INSTALLATION_ROOT/installed/${{ matrix.triplet }}
           CIBW_BEFORE_BUILD_WINDOWS: "python -m pip install delvewheel"
           CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: "delvewheel repair --add-path C:/vcpkg/installed/${{ matrix.triplet }}/bin -w {dest_dir} {wheel}"

--- a/ci/proj-compile-wheels.sh
+++ b/ci/proj-compile-wheels.sh
@@ -289,7 +289,7 @@ function build_proj {
     touch proj-stamp
 }
 
-function copy_cached_proj {
+function copy_cached_proj_to_build {
     if [ ! -d $PROJ_CACHE ]; then
         return 1
     fi
@@ -297,8 +297,13 @@ function copy_cached_proj {
     cp ${PROJ_CACHE}/* ${PROJ_DIR}/
 }
 
+function copy_build_proj_to_cache {
+    mkdir -p ${PROJ_CACHE}
+    cp ${PROJ_DIR}/* ${PROJ_CACHE}/
+}
 
-if copy_cached_proj ; then
+
+if copy_cached_proj_to_build ; then
     echo "Using cached PROJ build"
     exit 0
 fi
@@ -309,3 +314,4 @@ suppress build_zlib
 suppress build_sqlite
 suppress build_libtiff
 build_proj
+copy_build_proj_to_cache

--- a/ci/proj-compile-wheels.sh
+++ b/ci/proj-compile-wheels.sh
@@ -36,7 +36,6 @@ function update_env_for_build_prefix {
   # Promote BUILD_PREFIX on search path to any newly built libs
   export CPPFLAGS="-I$BUILD_PREFIX/include $CPPFLAGS_BACKUP"
   export LIBRARY_PATH="$BUILD_PREFIX/lib:$LIBRARY_PATH_BACKUP"
-  export LD_RUN_PATH="${BUILD_PREFI}/lib"
   export PKG_CONFIG_PATH="$BUILD_PREFIX/lib/pkgconfig/:$PKG_CONFIG_PATH_BACKUP"
   # Add binary path for configure utils etc
   export PATH="$BUILD_PREFIX/bin:$PATH"
@@ -301,8 +300,6 @@ function copy_cached_proj_to_build {
 
 function copy_build_proj_to_cache {
     mkdir -p ${PROJ_CACHE}
-    ls -l ${BUILD_PREFIX}
-    ls -l ${BUILD_PREFIX}/lib
     cp -Rv ${PROJ_DIR}/* ${PROJ_CACHE}/
 }
 

--- a/ci/proj-compile-wheels.sh
+++ b/ci/proj-compile-wheels.sh
@@ -291,7 +291,7 @@ function build_proj {
 
 function copy_cached_proj {
     if [ ! -d $PROJ_CACHE ]; then
-        exit 1
+        return 1
     fi
 
     cp ${PROJ_CACHE}/* ${PROJ_DIR}/

--- a/ci/proj-compile-wheels.sh
+++ b/ci/proj-compile-wheels.sh
@@ -294,12 +294,12 @@ function copy_cached_proj_to_build {
         return 1
     fi
 
-    cp ${PROJ_CACHE}/* ${PROJ_DIR}/
+    cp -r ${PROJ_CACHE}/* ${PROJ_DIR}/
 }
 
 function copy_build_proj_to_cache {
     mkdir -p ${PROJ_CACHE}
-    cp ${PROJ_DIR}/* ${PROJ_CACHE}/
+    cp -r ${PROJ_DIR}/* ${PROJ_CACHE}/
 }
 
 

--- a/ci/proj-compile-wheels.sh
+++ b/ci/proj-compile-wheels.sh
@@ -304,13 +304,14 @@ function copy_build_proj_to_cache {
 }
 
 
+update_env_for_build_prefix
+
 if copy_cached_proj_to_build ; then
     echo "Using cached PROJ build"
     exit 0
 fi
 
 # Run installation process
-update_env_for_build_prefix
 suppress build_zlib
 suppress build_sqlite
 suppress build_libtiff

--- a/ci/proj-compile-wheels.sh
+++ b/ci/proj-compile-wheels.sh
@@ -289,6 +289,20 @@ function build_proj {
     touch proj-stamp
 }
 
+function copy_cached_proj {
+    if [ -d $PROJ_CACHE ] {
+        exit 1
+    }
+
+    cp ${PROJ_CACHE}/* ${PROJ_DIR}/
+}
+
+
+if copy_cached_proj ; then
+    echo "Using cached PROJ build"
+    exit 0
+fi
+
 # Run installation process
 update_env_for_build_prefix
 suppress build_zlib

--- a/ci/proj-compile-wheels.sh
+++ b/ci/proj-compile-wheels.sh
@@ -300,6 +300,8 @@ function copy_cached_proj_to_build {
 
 function copy_build_proj_to_cache {
     mkdir -p ${PROJ_CACHE}
+    ls -l ${BUILD_PREFIX}
+    ls -l ${BUILD_PREFIX}/lib
     cp -Rv ${PROJ_DIR}/* ${PROJ_CACHE}/
 }
 

--- a/ci/proj-compile-wheels.sh
+++ b/ci/proj-compile-wheels.sh
@@ -294,12 +294,12 @@ function copy_cached_proj_to_build {
         return 1
     fi
 
-    cp -r ${PROJ_CACHE}/* ${PROJ_DIR}/
+    cp -R ${PROJ_CACHE}/* ${PROJ_DIR}/
 }
 
 function copy_build_proj_to_cache {
     mkdir -p ${PROJ_CACHE}
-    cp -r ${PROJ_DIR}/* ${PROJ_CACHE}/
+    cp -R ${PROJ_DIR}/* ${PROJ_CACHE}/
 }
 
 

--- a/ci/proj-compile-wheels.sh
+++ b/ci/proj-compile-wheels.sh
@@ -294,6 +294,7 @@ function copy_cached_proj_to_build {
         return 1
     fi
 
+    mkdir -p ${PROJ_DIR}/
     cp -Rv ${PROJ_CACHE}/* ${PROJ_DIR}/
 }
 

--- a/ci/proj-compile-wheels.sh
+++ b/ci/proj-compile-wheels.sh
@@ -290,7 +290,7 @@ function build_proj {
 }
 
 function copy_cached_proj {
-    if [ -d $PROJ_CACHE ]; then
+    if [ ! -d $PROJ_CACHE ]; then
         exit 1
     fi
 

--- a/ci/proj-compile-wheels.sh
+++ b/ci/proj-compile-wheels.sh
@@ -290,9 +290,9 @@ function build_proj {
 }
 
 function copy_cached_proj {
-    if [ -d $PROJ_CACHE ] {
+    if [ -d $PROJ_CACHE ]; then
         exit 1
-    }
+    fi
 
     cp ${PROJ_CACHE}/* ${PROJ_DIR}/
 }

--- a/ci/proj-compile-wheels.sh
+++ b/ci/proj-compile-wheels.sh
@@ -294,12 +294,12 @@ function copy_cached_proj_to_build {
         return 1
     fi
 
-    cp -R ${PROJ_CACHE}/* ${PROJ_DIR}/
+    cp -Rv ${PROJ_CACHE}/* ${PROJ_DIR}/
 }
 
 function copy_build_proj_to_cache {
     mkdir -p ${PROJ_CACHE}
-    cp -R ${PROJ_DIR}/* ${PROJ_CACHE}/
+    cp -Rv ${PROJ_DIR}/* ${PROJ_CACHE}/
 }
 
 

--- a/ci/proj-compile-wheels.sh
+++ b/ci/proj-compile-wheels.sh
@@ -36,6 +36,7 @@ function update_env_for_build_prefix {
   # Promote BUILD_PREFIX on search path to any newly built libs
   export CPPFLAGS="-I$BUILD_PREFIX/include $CPPFLAGS_BACKUP"
   export LIBRARY_PATH="$BUILD_PREFIX/lib:$LIBRARY_PATH_BACKUP"
+  export LD_RUN_PATH="${BUILD_PREFI}/lib"
   export PKG_CONFIG_PATH="$BUILD_PREFIX/lib/pkgconfig/:$PKG_CONFIG_PATH_BACKUP"
   # Add binary path for configure utils etc
   export PATH="$BUILD_PREFIX/bin:$PATH"


### PR DESCRIPTION
As discussed in #1342 PROJ building takes about 10 minutes at the top of every wheel build workflow. This PR caches it with GitHub Actions to hopefully remove this requirement except for when PROJ (or its dependencies) are updated.

This workflow is taken from shapely's own CI.

 - [ ] Closes #xxxx
 - [ ] Tests added
 - [ ] Fully documented, including `history.rst` for all changes and `api/*.rst` for new API
