### PR TITLE
PERF: drop GIL during long-running proj database calls

### DIFF
--- a/pyproj/_transformer.pyx
+++ b/pyproj/_transformer.pyx
@@ -330,14 +330,15 @@ cdef PJ* proj_create_crs_to_crs(
         ELSE:
             raise NotImplementedError("only_best requires PROJ 9.2+.")
 
-
-    cdef PJ* transform = proj_create_crs_to_crs_from_pj(
-        ctx,
-        source_crs,
-        target_crs,
-        area,
-        options,
-    )
+    cdef PJ* transform = NULL
+    with nogil:
+        transform = proj_create_crs_to_crs_from_pj(
+            ctx,
+            source_crs,
+            target_crs,
+            area,
+            options,
+        )
     proj_destroy(source_crs)
     proj_destroy(target_crs)
     if transform == NULL:


### PR DESCRIPTION
These calls can take hundreds of milliseconds to access the PROJ databases, during which time no other Python code in any other thread can run. Use `nogil` to avoid this effect.

This should be safe for these calls as they all take a separate PROJ threading context.

It's quite probable there are other calls which could use this, but these negatively affected my application and I was able to identify them. I would welcome additions to the set of calls to wrap.

<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [ ] Closes #xxxx
 - [ ] Tests added
 - [ ] Fully documented, including `history.rst` for all changes and `api/*.rst` for new API
