### PR TITLE
DEP: Minimum supported Python version 3.10

### DIFF
--- a/.github/workflows/build_docs.yaml
+++ b/.github/workflows/build_docs.yaml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Conda
         uses: s-weigand/setup-conda@v1
         with:
-          python-version: 3.9
+          python-version: '3.11'
           conda-channels: conda-forge
 
       - name: Install and Build
@@ -31,7 +31,7 @@ jobs:
         run: |
           conda config --prepend channels conda-forge
           conda config --set channel_priority strict
-          conda create -n docs python=3.9 cython proj
+          conda create -n docs python=3.11 cython proj
           source activate docs
           python -m pip install -e .
           python -m pip install -r requirements-docs.txt

--- a/.github/workflows/test_proj_latest.yaml
+++ b/.github/workflows/test_proj_latest.yaml
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v4
         with:
-            python-version: 3.9
+            python-version: '3.11'
       - name: Install PROJ
         shell: bash
         run: |

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v4
         with:
-            python-version: 3.9
+            python-version: '3.10'
       - uses: pre-commit/action@v3.0.0
       - name: Install mypy
         run: |
@@ -40,16 +40,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.10', '3.11', '3.12']
         proj-version: ['9.3.0']
         include:
-          - python-version: '3.9'
+          - python-version: '3.10'
             proj-version: '9.2.1'
-          - python-version: '3.9'
+          - python-version: '3.10'
             proj-version: '9.1.1'
-          - python-version: '3.9'
+          - python-version: '3.10'
             proj-version: '9.1.0'
-          - python-version: '3.9'
+          - python-version: '3.10'
             proj-version: '9.0.1'
     steps:
       - uses: actions/checkout@v4
@@ -125,14 +125,15 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.9', '3.10', '3.11']
+        python-version: ['3.10', '3.11', '3.12']
         python-implementation: [python]
         proj-version: ['*']
         include:
-          - os: ubuntu-latest
-            python-version: '*'
-            python-implementation: pypy
-            proj-version: '*'
+          # DISABLED UNTIL CONDA-FORGE PYPY SUPPORTS PYTHON 3.10+
+          # - os: ubuntu-latest
+          #   python-version: '*'
+          #   python-implementation: pypy
+          #   proj-version: '*'
           - os: ubuntu-latest
             python-version: '*'
             python-implementation: python
@@ -150,12 +151,7 @@ jobs:
         run: |
           conda config --prepend channels conda-forge
           conda config --set channel_priority strict
-          export INSTALL_DEPS='${{ matrix.python-implementation }}=${{ matrix.python-version }} cython proj=${{ matrix.proj-version }} numpy'
-          if [ "${{ matrix.os }}" = "macos-latest" -a "${{ matrix.python-version }}" = "3.10" ]; then
-            sed -i.bak '/shapely/d' requirements-test.txt;
-          else
-            export INSTALL_DEPS="${INSTALL_DEPS} shapely";
-          fi;
+          export INSTALL_DEPS='${{ matrix.python-implementation }}=${{ matrix.python-version }} cython proj=${{ matrix.proj-version }} numpy shapely'
           if [ "${{ matrix.python-implementation }}" = "pypy" ]; then
             sed -i.bak '/xarray/d' requirements-test.txt;
             sed -i.bak '/pandas/d' requirements-test.txt;

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,17 +13,17 @@ environment:
     # See: http://www.appveyor.com/docs/installed-software#python
     # build is limited to 60 minutes, without caching each build takes 10-30 minutes
     # with caching build takes less than 1 minute
-    - PYTHON: "C:\\Python39-x64"
+    - PYTHON: "C:\\Python310-x64"
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
       PROJSOURCE: 9.3.0
       BUILD_SHARED_LIBS: ON
-    # - PYTHON: "C:\\Python39-x64"
+    # - PYTHON: "C:\\Python310-x64"
     #   APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
     #   PROJSOURCE: git
     #   BUILD_SHARED_LIBS: ON
 # matrix:
 #   allow_failures:
-#     - PYTHON: "C:\\Python39-x64"
+#     - PYTHON: "C:\\Python310-x64"
 #       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
 #       PROJSOURCE: git
 #       BUILD_SHARED_LIBS: ON

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -3,6 +3,7 @@ Change Log
 
 Latest
 ------
+- DEP: Minimum supported Python version 3.10 (pull #1357)
 
 3.6.1
 ------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -7,7 +7,7 @@ GitHub Repository: https://github.com/pyproj4/pyproj
 
 .. note:: Minimum supported PROJ version is 9.0
 
-.. note:: Minimum supported Python version is 3.9
+.. note:: Minimum supported Python version is 3.10
 
 .. note:: Linux (manylinux2014) wheels require pip 19.3+
 

--- a/pyproj/__init__.py
+++ b/pyproj/__init__.py
@@ -4,7 +4,7 @@ cartographic projections and coordinate transformations library.
 
 Download: http://python.org/pypi/pyproj
 
-Requirements: Python 3.9+.
+Requirements: Python 10+.
 
 Contact:  Jeffrey Whitaker <jeffrey.s.whitaker@noaa.gov>
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,6 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
     "Programming Language :: Python",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
@@ -40,7 +39,7 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Typing :: Typed",
 ]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dependencies = [
     "certifi",
 ]
@@ -64,4 +63,4 @@ include = ["pyproj", "pyproj.*"]
 version = {attr = "pyproj.__version__"}
 
 [tool.black]
-target_version = ["py39"]
+target_version = ["py310"]


### PR DESCRIPTION
Python 3.9 is no longer supported in the scientific python ecosystem: https://scientific-python.org/specs/spec-0000/

Related #1111