### PR TITLE
BUG: Support azimuthal_equidistant coordinate operation to CF

### DIFF
--- a/pyproj/crs/_cf1x8.py
+++ b/pyproj/crs/_cf1x8.py
@@ -658,6 +658,7 @@ def _pole_rotation_netcdf__to_cf(conversion):
 _INVERSE_GRID_MAPPING_NAME_MAP = {
     "albers_equal_area": _albers_conical_equal_area__to_cf,
     "modified_azimuthal_equidistant": _azimuthal_equidistant__to_cf,
+    "azimuthal_equidistant": _azimuthal_equidistant__to_cf,
     "geostationary_satellite_(sweep_x)": _geostationary__to_cf,
     "geostationary_satellite_(sweep_y)": _geostationary__to_cf,
     "lambert_azimuthal_equal_area": _lambert_azimuthal_equal_area__to_cf,


### PR DESCRIPTION
Related: https://github.com/OSGeo/PROJ/pull/3988

```
_________________________ test_azimuthal_equidistant __________________________

    def test_azimuthal_equidistant():
        crs = CRS("ESRI:54032")
        expected_cf = {
            "semi_major_axis": 6378137.0,
            "semi_minor_axis": crs.ellipsoid.semi_minor_metre,
            "inverse_flattening": crs.ellipsoid.inverse_flattening,
            "reference_ellipsoid_name": "WGS 84",
            "longitude_of_prime_meridian": 0.0,
            "prime_meridian_name": "Greenwich",
            "geographic_crs_name": "WGS 84",
            "horizontal_datum_name": "World Geodetic System 1984",
            "projected_crs_name": "World_Azimuthal_Equidistant",
            "grid_mapping_name": "azimuthal_equidistant",
            "latitude_of_projection_origin": 0.0,
            "longitude_of_projection_origin": 0.0,
            "false_easting": 0.0,
            "false_northing": 0.0,
        }
        cf_dict = crs.to_cf()
        assert cf_dict.pop("crs_wkt").startswith("PROJCRS[")
>       assert cf_dict == expected_cf
E       AssertionError: assert {} == {'false_easti...distant', ...}
E         
E         Right contains 14 more items:
E         {'false_easting': 0.0,
E          'false_northing': 0.0,
E          'geographic_crs_name': 'WGS 84',
E          'grid_mapping_name': 'azimuthal_equidistant',
E          'horizontal_datum_name': 'World Geodetic System 1984',
E          'inverse_flattening': 298.257223563,
E          'latitude_of_projection_origin': 0.0,
E          'longitude_of_prime_meridian': 0.0,
E          'longitude_of_projection_origin': 0.0,
E          'prime_meridian_name': 'Greenwich',
E          'projected_crs_name': 'World_Azimuthal_Equidistant',
E          'reference_ellipsoid_name': 'WGS 84',
E          'semi_major_axis': 6378137.0,
E          'semi_minor_axis': 6356752.314245179}
E         
E         Full diff:
E         + {}
E         - {
E         -     'false_easting': 0.0,
E         -     'false_northing': 0.0,
E         -     'geographic_crs_name': 'WGS 84',
E         -     'grid_mapping_name': 'azimuthal_equidistant',
E         -     'horizontal_datum_name': 'World Geodetic System 1984',
E         -     'inverse_flattening': 298.257223563,
E         -     'latitude_of_projection_origin': 0.0,
E         -     'longitude_of_prime_meridian': 0.0,
E         -     'longitude_of_projection_origin': 0.0,
E         -     'prime_meridian_name': 'Greenwich',
E         -     'projected_crs_name': 'World_Azimuthal_Equidistant',
E         -     'reference_ellipsoid_name': 'WGS 84',
E         -     'semi_major_axis': 6378137.0,
E         -     'semi_minor_axis': 6356752.314245179,
E         - }
```