### PR TITLE
Adds codespell to pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,3 +33,7 @@ repos:
             types:
             - file
             args: [--append-config=flake8/cython.cfg]
+    -   repo: https://github.com/codespell-project/codespell
+        rev: v2.2.6
+        hooks:
+        -   id: codespell

--- a/HOW_TO_RELEASE.md
+++ b/HOW_TO_RELEASE.md
@@ -43,7 +43,7 @@ Next, go through the history and add release notes (see: [automatically generate
 
 Most of the wheels are tested with each merge to main and uploaded to pypi on release in GitHub Actions. However, the arm64 wheels are built separately. This provides instructions for those wheels:
 
-1. linux arm64: Update the PR at https://github.com/pyproj4/pyproj-wheels with the release tag & merge. The wheels will automatically upload to pypi when the CI runs suceed.
+1. linux arm64: Update the PR at https://github.com/pyproj4/pyproj-wheels with the release tag & merge. The wheels will automatically upload to pypi when the CI runs succeed.
 2. macos arm64: Download the release wheel artifacts from the Cirrus CI build and upload manually to pypi.
 
 ### Verify conda-forge build is correct

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -155,7 +155,7 @@ Latest
 * ENH: Added :ref:`network_api` (#675, #691, #695)
 * ENH: Added ability to use global context (issue #661)
 * ENH: Added transformation grid sync API/CLI (issue #572)
-* ENH: Support obects with '__array__' method (pandas.Series, xarray.DataArray, dask.array.Array) (issue #573)
+* ENH: Support objects with '__array__' method (pandas.Series, xarray.DataArray, dask.array.Array) (issue #573)
 * ENH: Added :func:`pyproj.datadir.get_user_data_dir` (pull #636)
 * ENH: Added :attr:`pyproj.transformer.Transformer.is_network_enabled` (issue #629)
 * ENH: Added :meth:`pyproj.transformer.TransformerGroup.download_grids` (pull #643)

--- a/pyproj/crs/coordinate_operation.py
+++ b/pyproj/crs/coordinate_operation.py
@@ -1290,7 +1290,7 @@ class VerticalPerspectiveConversion(CoordinateOperation):
     """
     .. versionadded:: 2.5.0
 
-    Class for constructing the Vetical Perspective conversion.
+    Class for constructing the Vertical Perspective conversion.
 
     :ref:`PROJ docs <nsper>`
     """

--- a/pyproj/crs/crs.py
+++ b/pyproj/crs/crs.py
@@ -1998,7 +1998,7 @@ class VerticalCRS(CustomConstructorCRS):
     """
     .. versionadded:: 2.5.0
 
-    This class is for building a Vetical CRS.
+    This class is for building a Vertical CRS.
 
     .. warning:: geoid_model support only exists in PROJ >= 6.3.0
 


### PR DESCRIPTION
Adds [`codespell`](https://github.com/codespell-project/codespell) to pre-commit hooks to catch common misspellings. Includes fixes for a few existing misspellings in repo

```
check yaml...............................................................Passed
fix end of files.........................................................Passed
trim trailing whitespace.................................................Passed
black....................................................................Passed
isort....................................................................Passed
blacken-docs.............................................................Passed
flake8...................................................................Passed
flake8-pyx...............................................................Passed
codespell................................................................Failed
- hook id: codespell
- exit code: 65

pyproj/crs/coordinate_operation.py:1293: Vetical ==> Vertical
pyproj/crs/crs.py:2001: Vetical ==> Vertical
HOW_TO_RELEASE.md:46: suceed ==> succeed
docs/history.rst:158: obects ==> objects

```