### PR TITLE
CI: Macos 11 -> Macos 12

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -65,7 +65,7 @@ jobs:
           arch: x86_64
         # - os: ubuntu-22.04
         #   arch: i686
-        - os: macos-11
+        - os: macos-12
           arch: x86_64
           cmake_osx_architectures: x86_64
         - os: macos-14
@@ -131,7 +131,6 @@ jobs:
             PROJ_NETWORK=ON
             PROJ_VERSION=${{ env.PROJ_VERSION }}
             PROJ_DIR=${GITHUB_WORKSPACE}/pyproj/proj_dir
-            MACOSX_DEPLOYMENT_TARGET=10.9
             CMAKE_OSX_ARCHITECTURES='${{ matrix.cmake_osx_architectures }}'
             LDFLAGS="${LDFLAGS} -Wl,-rpath,${GITHUB_WORKSPACE}/pyproj/proj_dir/lib"
           CIBW_ENVIRONMENT_WINDOWS:


### PR DESCRIPTION
- https://github.com/actions/runner-images
- https://github.blog/changelog/2024-05-20-actions-upcoming-changes-to-github-hosted-macos-runners/