### PR TITLE
BUG: Address cython nogil signature warning

### DIFF
--- a/pyproj/_context.pyx
+++ b/pyproj/_context.pyx
@@ -107,7 +107,7 @@ cpdef void _clear_proj_error() noexcept:
     _INTERNAL_PROJ_ERROR = None
 
 
-cdef void pyproj_log_function(void *user_data, int level, const char *error_msg) nogil noexcept:
+cdef void pyproj_log_function(void *user_data, int level, const char *error_msg) noexcept nogil:
     """
     Log function for catching PROJ errors.
     """


### PR DESCRIPTION
```
warning: pyproj/_context.pyx:110:95: The keyword 'nogil' should appear at the end of the function signature line. Placing it before 'except' or 'noexcept' will be disallowed in a future version of Cython.
```