### PR TITLE
Update crs_compatibility.rst to fix a title

### DIFF
--- a/docs/crs_compatibility.rst
+++ b/docs/crs_compatibility.rst
@@ -267,7 +267,7 @@ Preparing `pyproj.crs.CRS` for `pycrs`
     py_crs = pycrs.parse.from_ogc_wkt(proj_crs.to_wkt("WKT1_GDAL"))
 
 
-Preparing `cartopy.crs.CRS` for `pyproj.crs.CRS`
+Preparing `pycrs` for `pyproj.crs.CRS`
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code-block:: python
 


### PR DESCRIPTION
Change title to correct one, was saying cartopy when that was the previous section.