### PR TITLE
BLD: Add Windows system path to delvewheel add-path

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -112,6 +112,11 @@ jobs:
           VCPKG_DEFAULT_TRIPLET: ${{ matrix.triplet }}
         shell: bash
         run: |
+          # Workaround for vcpkg downloading issue:
+          # https://github.com/microsoft/vcpkg/issues/41199#issuecomment-2378255699
+          export SystemDrive="$SYSTEMDRIVE"
+          export SystemRoot="$SYSTEMROOT"
+          export windir="$WINDIR"
           cd "$VCPKG_INSTALLATION_ROOT"
           git pull > nul
           ./bootstrap-vcpkg.bat -disableMetrics
@@ -143,7 +148,8 @@ jobs:
             PROJ_VERSION=${{ env.PROJ_VERSION }}
             PROJ_DIR=$VCPKG_INSTALLATION_ROOT/installed/${{ matrix.triplet }}
           CIBW_BEFORE_BUILD_WINDOWS: "python -m pip install delvewheel"
-          CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: "delvewheel repair --add-path C:/vcpkg/installed/${{ matrix.triplet }}/bin -w {dest_dir} {wheel}"
+          # Add Windows System32 explicitly to the path https://github.com/adang1345/delvewheel/issues/54
+          CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: "delvewheel repair --add-path C:/Windows/System32 --add-path C:/vcpkg/installed/${{ matrix.triplet }}/bin -w {dest_dir} {wheel}"
           CIBW_BEFORE_ALL_LINUX: bash ./ci/proj-compile-wheels.sh
           CIBW_BEFORE_ALL_MACOS: bash ./ci/proj-compile-wheels.sh
           CIBW_TEST_REQUIRES: cython pytest numpy --config-settings=setup-args="-Dallow-noblas=true"


### PR DESCRIPTION
xref: https://github.com/adang1345/delvewheel/issues/54

Additionally, vcpkg has a download error when running with a bash shell so we need to add some extra exports as a workaround. https://github.com/microsoft/vcpkg/issues/41199#issuecomment-2378255699

<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Closes #1425
 - [n/a] Tests added
 - [x] Fully documented, including `history.rst` for all changes and `api/*.rst` for new API
