### PR TITLE
MNT: Add too-many-positional-arguments to lint ignore rules

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -23,6 +23,7 @@ disable=cyclic-import,
         too-few-public-methods,
         too-many-arguments,
         too-many-locals,
+        too-many-positional-arguments,
         too-many-public-methods
 
 


### PR DESCRIPTION
pylint 3.3.0 added a new rule that is causing failures. There is already an ignore rule for too many arguments, so also add the ignore rule for the positional specific arguments.