### PR TITLE
CI: Pin micromamba due to CI Runner incompatibilities with newer versions

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -119,6 +119,8 @@ jobs:
       - name: Setup Conda
         uses: mamba-org/setup-micromamba@v1
         with:
+          # https://github.com/mamba-org/setup-micromamba/issues/225
+          micromamba-version: 1.5.10-0
           init-shell: bash
           environment-name: test
           create-args: >-


### PR DESCRIPTION
Looks like micromamba v2 release doesn't work on GitHub Actions runners currently, so pin the version back.

xref: https://github.com/mamba-org/setup-micromamba/issues/225