### PR TITLE
Disallow type error without code

### DIFF
--- a/pyproj/crs/coordinate_operation.py
+++ b/pyproj/crs/coordinate_operation.py
@@ -604,7 +604,7 @@ class LambertCylindricalEqualAreaScaleConversion(CoordinateOperation):
             f"+k_0={scale_factor_natural_origin}"
         )
         return cls.from_json(
-            CRS(proj_string).coordinate_operation.to_json()  # type: ignore
+            CRS(proj_string).coordinate_operation.to_json()  # type: ignore[union-attr]
         )
 
 

--- a/pyproj/crs/crs.py
+++ b/pyproj/crs/crs.py
@@ -334,7 +334,7 @@ class CRS:
             elif isinstance(projparams, (list, tuple)) and len(projparams) == 2:
                 projstring = _prepare_from_authority(*projparams)
             elif hasattr(projparams, "to_wkt"):
-                projstring = projparams.to_wkt()  # type: ignore
+                projstring = projparams.to_wkt()
             else:
                 raise CRSError(f"Invalid CRS input: {projparams!r}")
 

--- a/pyproj/geod.py
+++ b/pyproj/geod.py
@@ -1003,7 +1003,7 @@ class Geod(_Geod):
             The total geodesic length of the geometry (meters).
         """
         try:
-            return self.line_length(*geometry.xy, radians=radians)  # type: ignore
+            return self.line_length(*geometry.xy, radians=radians)  # type: ignore[misc]
         except (AttributeError, NotImplementedError):
             pass
         if hasattr(geometry, "exterior"):
@@ -1074,7 +1074,7 @@ class Geod(_Geod):
             The geodesic area (meters^2) and perimeter (meters) of the polygon.
         """
         try:
-            return self.polygon_area_perimeter(  # type: ignore
+            return self.polygon_area_perimeter(  # type: ignore[misc]
                 *geometry.xy, radians=radians
             )
         except (AttributeError, NotImplementedError):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,8 +110,8 @@ select = [
   "RUF",
   # flake8-bandit: exec-builtin
   "S102",
-  # numpy-legacy-random
-  "NPY002",
+  # NumPy-specific rules
+  "NPY",
   # Perflint
   "PERF",
   # flynt
@@ -123,7 +123,7 @@ select = [
   # flake8-slots
   "SLOT",
   # flake8-raise
-  "RSE"
+  "RSE",
 ]
 
 ignore = [
@@ -146,10 +146,6 @@ ignore = [
     ### TODO: Enable gradually
     # Rename unused
     "B007",
-    # Use specific rule codes when ignoring type issues
-    "PGH003",
-    # unconventional-import-alias
-    "ICN001",
     # Move standard library import into a type-checking block
     "TCH003",
     # Consider f-string instead of string join
@@ -158,3 +154,9 @@ ignore = [
     "PERF401"
 
 ]
+
+[tool.mypy]
+files = ["pyproj"]
+python_version = "3.10"
+ignore_errors = false
+enable_error_code = "ignore-without-code"


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

I strengthen the `mypy` and `ruff` config a bit to disallow `type: ignore` with no code, found one case when the ignore can be removed
