### PR TITLE
CI: Add wheels for musllinux (closes #1382)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -127,7 +127,7 @@ jobs:
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.22
         env:
-          CIBW_SKIP: "*musllinux* pp*-win* pp31*"
+          CIBW_SKIP: "pp*-win* pp31*"
           CIBW_ARCHS: ${{ matrix.arch }}
           CIBW_ENVIRONMENT_LINUX:
             PROJ_WHEEL=true

--- a/ci/proj-compile-wheels.sh
+++ b/ci/proj-compile-wheels.sh
@@ -19,6 +19,10 @@ if [ $(uname) == "Darwin" ]; then
   IS_MACOS=1;
 fi
 
+if [ -f /etc/alpine-release ]; then
+  IS_ALPINE=1
+fi
+
 if [ -z "$IS_MACOS" ]; then
     # Strip all binaries after compilation.
     STRIP_FLAGS=${STRIP_FLAGS:-"-Wl,-strip-all"}
@@ -100,6 +104,8 @@ function install_rsync {
     if [ -n "$IS_MACOS" ]; then
         # macOS. The colon in the next line is the null command
         :
+    elif [ -n "$IS_ALPINE" ]; then
+        [[ $(type -P rsync) ]] || apk add rsync
     elif [[ $MB_ML_VER == "_2_24" ]]; then
         # debian:9 based distro
         [[ $(type -P rsync) ]] || apt-get install -y rsync
@@ -177,6 +183,7 @@ function build_simple {
 
 function get_modern_cmake {
     # Install cmake >= 2.8
+    if [ -n "$IS_ALPINE" ]; then return; fi  # alpine has modern cmake already
     local cmake=cmake
     if [ -n "$IS_MACOS" ]; then
         brew install cmake > /dev/null
@@ -196,6 +203,7 @@ function get_modern_cmake {
 function build_zlib {
     # Gives an old but safe version
     if [ -n "$IS_MACOS" ]; then return; fi  # OSX has zlib already
+    if [ -n "$IS_ALPINE" ]; then return; fi  # alpine has zlib already
     if [ -e zlib-stamp ]; then return; fi
     if [[ $MB_ML_VER == "_2_24" ]]; then
         # debian:9 based distro
@@ -209,6 +217,7 @@ function build_zlib {
 
 function build_perl {
     if [ -n "$IS_MACOS" ]; then return; fi  # OSX has perl already
+    if [ -n "$IS_ALPINE" ]; then return; fi  # alpine has perl already
     if [ -e perl-stamp ]; then return; fi
     if [[ $MB_ML_VER == "_2_24" ]]; then
         # debian:9 based distro


### PR DESCRIPTION
I wasn't sure if I could safely run github CI on my fork, so there might be some issues that I missed.
I did test these changes locally though using a local installation of `cibuildwheel` and this script:
```bash
#!/usr/bin/env bash

export CIBW_SKIP="pp*-win* pp31*"
export CIBW_ARCHS="x86_64"
export CIBW_ENVIRONMENT_LINUX="PROJ_WHEEL=true PROJ_NETWORK=ON PROJ_VERSION=9.5.0 PROJ_DIR=/project/pyproj/proj_dir"
export CIBW_BEFORE_ALL_LINUX="bash ./ci/proj-compile-wheels.sh"
export CIBW_TEST_REQUIRES="cython pytest numpy --config-settings=setup-args=\"-Dallow-noblas=true\""
export CIBW_BEFORE_TEST="python -m pip install shapely pandas xarray || echo \"Optional requirements install failed \""
export CIBW_TEST_COMMAND="pyproj -v && python -c \"import pyproj; pyproj.Proj(init='epsg:4269')\" && cp -r {package}/test . && python -m pytest test -v -s"

cibuildwheel
```

The commit message contains some more information on the changes. Let me know if you have questions or if something is missing.