### PR TITLE
CI: Update to macos 13 runner & add linux arm runner

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -64,12 +64,12 @@ jobs:
         include:
         - os: ubuntu-22.04
           arch: x86_64
-        # - os: ubuntu-22.04
-        #   arch: i686
-        - os: macos-12
+        - os: ubuntu-22.04-arm
+          arch: aarch64
+        - os: macos-13
           arch: x86_64
           cmake_osx_architectures: x86_64
-          macos_deployment_target: "12.0"
+          macos_deployment_target: "13.0"
         - os: macos-14
           arch: arm64
           cmake_osx_architectures: arm64

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -3,7 +3,7 @@ Change Log
 
 Latest
 ------
-
+- WHL: MacOS minimum deployment target moved to 13 (pull #1475)
 
 3.7.0
 ------


### PR DESCRIPTION
- https://github.blog/changelog/2024-09-03-github-actions-arm64-linux-and-windows-runners-are-now-generally-available/
- https://github.com/actions/runner-images/issues/10721