### PR TITLE
pyproj.crs: add imports to __all__

### DIFF
--- a/pyproj/crs/__init__.py
+++ b/pyproj/crs/__init__.py
@@ -4,7 +4,7 @@ to the coordinate reference system (CRS) information through the CRS
 class.
 """
 
-from pyproj._crs import (  # noqa: F401  pylint: disable=unused-import
+from pyproj._crs import (
     CoordinateOperation,
     CoordinateSystem,
     Datum,
@@ -13,7 +13,7 @@ from pyproj._crs import (  # noqa: F401  pylint: disable=unused-import
     is_proj,
     is_wkt,
 )
-from pyproj.crs.crs import (  # noqa: F401  pylint: disable=unused-import
+from pyproj.crs.crs import (
     CRS,
     BoundCRS,
     CompoundCRS,
@@ -24,4 +24,25 @@ from pyproj.crs.crs import (  # noqa: F401  pylint: disable=unused-import
     ProjectedCRS,
     VerticalCRS,
 )
-from pyproj.exceptions import CRSError  # noqa: F401  pylint: disable=unused-import
+from pyproj.exceptions import CRSError
+
+
+__all__ = [
+    "CoordinateOperation",
+    "CoordinateSystem",
+    "Datum",
+    "Ellipsoid",
+    "PrimeMeridian",
+    "is_proj",
+    "is_wkt",
+    "CRS",
+    "BoundCRS",
+    "CompoundCRS",
+    "CustomConstructorCRS",
+    "DerivedGeographicCRS",
+    "GeocentricCRS",
+    "GeographicCRS",
+    "ProjectedCRS",
+    "VerticalCRS",
+    "CRSError",
+]

--- a/pyproj/crs/__init__.py
+++ b/pyproj/crs/__init__.py
@@ -4,7 +4,7 @@ to the coordinate reference system (CRS) information through the CRS
 class.
 """
 
-from pyproj._crs import (
+from pyproj._crs import (  # noqa: F401  pylint: disable=unused-import
     CoordinateOperation,
     CoordinateSystem,
     Datum,
@@ -24,14 +24,10 @@ from pyproj.crs.crs import (
     ProjectedCRS,
     VerticalCRS,
 )
-from pyproj.exceptions import CRSError
+from pyproj.exceptions import CRSError  # noqa: F401  pylint: disable=unused-import
 
 __all__ = [
-    "CoordinateOperation",
     "CoordinateSystem",
-    "Datum",
-    "Ellipsoid",
-    "PrimeMeridian",
     "is_proj",
     "is_wkt",
     "CRS",
@@ -43,5 +39,4 @@ __all__ = [
     "GeographicCRS",
     "ProjectedCRS",
     "VerticalCRS",
-    "CRSError",
 ]

--- a/pyproj/crs/__init__.py
+++ b/pyproj/crs/__init__.py
@@ -27,7 +27,6 @@ from pyproj.crs.crs import (
 from pyproj.exceptions import CRSError  # noqa: F401  pylint: disable=unused-import
 
 __all__ = [
-    "CoordinateSystem",
     "is_proj",
     "is_wkt",
     "CRS",

--- a/pyproj/crs/__init__.py
+++ b/pyproj/crs/__init__.py
@@ -26,7 +26,6 @@ from pyproj.crs.crs import (
 )
 from pyproj.exceptions import CRSError
 
-
 __all__ = [
     "CoordinateOperation",
     "CoordinateSystem",


### PR DESCRIPTION
This PR explicitly exports all classes in `pyproj.crs`, allowing type checkers like mypy to better use the type hints. Without this change, mypy will complain with an error like:
```console
> mypy --strict foo.py
foo.py:3: error: Module "pyproj.crs" does not explicitly export attribute "CRS"  [attr-defined]
```