### PR TITLE
MNT: replace black and isort with ruff format and lint

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,3 +1,0 @@
-[settings]
-known_first_party=pyproj,test
-profile=black

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,15 +8,6 @@ repos:
         -   id: check-yaml
         -   id: end-of-file-fixer
         -   id: trailing-whitespace
-    -   repo: https://github.com/psf/black-pre-commit-mirror
-        rev: 24.2.0
-        hooks:
-        -   id: black
-    -   repo: https://github.com/pycqa/isort
-        rev: 5.13.2
-        hooks:
-        -   id: isort
-            args: [setup.py, pyproj/, test/, docs/]
     -   repo: https://github.com/asottile/blacken-docs
         rev: 1.16.0
         hooks:
@@ -38,6 +29,7 @@ repos:
         hooks:
         -   id: codespell
     -   repo: https://github.com/astral-sh/ruff-pre-commit
-        rev: v0.7.1
+        rev: v0.11.10
         hooks:
-        - id: ruff
+        - id: ruff-check
+        - id: ruff-format

--- a/.stickler.yml
+++ b/.stickler.yml
@@ -1,4 +1,0 @@
-linters:
-  flake8:
-    python: 3
-    max-line-length: 88

--- a/.stickler.yml
+++ b/.stickler.yml
@@ -1,6 +1,4 @@
 linters:
-  black:
-    config: ./pyproject.toml
   flake8:
     python: 3
     max-line-length: 88

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -167,10 +167,10 @@ There are plenty of more advanced testing concepts, like dealing with floating p
 comparisons, parameterizing tests, testing that exceptions are raised, and more. Have a look at the existing tests to get an idea of some of the common patterns.
 
 ## Code Style
-pyproj uses the Python code style outlined in [PEP8](https://pep8.org) and [black](https://github.com/python/black).
+pyproj uses the Python code style outlined in [PEP8](https://pep8.org) and by [the Ruff formatter](https://docs.astral.sh/ruff/formatter/).
 
 We enforce this style as code is added to keep everything clean and uniform. To this end, part of the automated testing for pyproj checks style. To check style
-locally within the source directory you can use the ``flake8`` and ``black`` tools. Running it from the root of the source directory is as easy as running ``pre-commit run --all`` in the base of the repository.
+locally within the source directory you can use the ``flake8`` and ``ruff format`` tools. Running it from the root of the source directory is as easy as running ``pre-commit run --all`` in the base of the repository.
 
 You can also just submit your PR and the kind robots will comment on all style violations as well. It can be a pain to make sure you have the right number of spaces around things, imports in order, and all of the other nits that the bots will find. It is very important though as this consistent style helps us keep pyproj readable, maintainable, and uniform.
 
@@ -192,7 +192,7 @@ Some things that will increase the chance that your pull request is accepted qui
 
 * Write tests.
 * Follow [PEP8](https://pep8.org) for style. (The `flake8` utility can help with this.)
-* Use [black](https://github.com/python/black)
+* Use [ruff format](https://docs.astral.sh/ruff/formatter/)
 * Write a [good commit message](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html) and consider using commit [conventions](https://www.conventionalcommits.org/).
 
 Pull requests will automatically have tests run by Travis. This includes

--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@ Python interface to [PROJ](http://proj.org) (cartographic projections and coordi
 <a href="https://badge.fury.io/py/pyproj"><img alt="PyPI" src="https://badge.fury.io/py/pyproj.svg"></a>
 <a href="https://pepy.tech/project/pyproj"><img alt="Downloads" src="https://pepy.tech/badge/pyproj"></a>
 <a href="https://anaconda.org/conda-forge/pyproj"><img alt="Anaconda-Server Badge" src="https://anaconda.org/conda-forge/pyproj/badges/version.svg"></a>
-<a href="https://github.com/python/black"><img alt="Code style: black" src="https://img.shields.io/badge/code%20style-black-000000.svg"></a>
 <a href="https://github.com/pre-commit/pre-commit"><img alt="pre-commit" src="https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white"></a>
 <a href="https://zenodo.org/badge/latestdoi/28607354"><img alt="DOI" src="https://zenodo.org/badge/28607354.svg"></a>
 </p>

--- a/pyproj/__init__.py
+++ b/pyproj/__init__.py
@@ -73,19 +73,19 @@ from pyproj.transformer import (  # noqa: F401 pylint: disable=unused-import
 
 __version__ = "3.7.2.dev0"
 __all__ = [
-    "Proj",
-    "Geod",
     "CRS",
+    "Geod",
+    "Proj",
     "Transformer",
-    "transform",
-    "itransform",
-    "pj_ellps",
-    "pj_list",
     "get_ellps_map",
     "get_prime_meridians_map",
     "get_proj_operations_map",
     "get_units_map",
+    "itransform",
+    "pj_ellps",
+    "pj_list",
     "show_versions",
+    "transform",
 ]
 __proj_version__ = PROJ_VERSION_STR
 proj_version_str = PROJ_VERSION_STR  # pylint: disable=invalid-name

--- a/pyproj/crs/__init__.py
+++ b/pyproj/crs/__init__.py
@@ -27,8 +27,6 @@ from pyproj.crs.crs import (
 from pyproj.exceptions import CRSError  # noqa: F401  pylint: disable=unused-import
 
 __all__ = [
-    "is_proj",
-    "is_wkt",
     "CRS",
     "BoundCRS",
     "CompoundCRS",
@@ -38,4 +36,6 @@ __all__ = [
     "GeographicCRS",
     "ProjectedCRS",
     "VerticalCRS",
+    "is_proj",
+    "is_wkt",
 ]

--- a/pyproj/geod.py
+++ b/pyproj/geod.py
@@ -10,10 +10,10 @@ latitudes and longitudes of an initial and terminus point.
 
 __all__ = [
     "Geod",
-    "pj_ellps",
-    "geodesic_version_str",
     "GeodIntermediateFlag",
     "GeodIntermediateReturn",
+    "geodesic_version_str",
+    "pj_ellps",
     "reverse_azimuth",
 ]
 

--- a/pyproj/transformer.py
+++ b/pyproj/transformer.py
@@ -3,11 +3,11 @@ The transformer module is for performing cartographic transformations.
 """
 
 __all__ = [
-    "transform",
-    "itransform",
+    "AreaOfInterest",
     "Transformer",
     "TransformerGroup",
-    "AreaOfInterest",
+    "itransform",
+    "transform",
 ]
 import threading
 import warnings
@@ -329,8 +329,7 @@ class Transformer:
         if not isinstance(transformer_maker, TransformerMaker):
             _clear_proj_error()
             raise ProjError(
-                "Transformer must be initialized using: "
-                "'from_crs' or 'from_pipeline'."
+                "Transformer must be initialized using: 'from_crs' or 'from_pipeline'."
             )
 
         self._local = TransformerLocal()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,12 +62,8 @@ include = ["pyproj", "pyproj.*"]
 [tool.setuptools.dynamic]
 version = {attr = "pyproj.__version__"}
 
-[tool.black]
-target_version = ["py310"]
-
 [tool.ruff]
 line-length = 88
-target-version = "py310"
 fix = true
 
 [tool.ruff.lint]
@@ -78,6 +74,8 @@ select = [
   "F",
   # pycodestyle
   "E", "W",
+  # isort
+  "I",
   # flake8-2020
   "YTT",
   # flake8-bugbear
@@ -101,7 +99,7 @@ select = [
   # implicit string concatenation
   "ISC",
   # type-checking imports
-  "TCH",
+  "TC",
   # comprehensions
   "C4",
   # pygrep-hooks
@@ -147,7 +145,7 @@ ignore = [
     # Rename unused
     "B007",
     # Move standard library import into a type-checking block
-    "TCH003",
+    "TC003",
     # Consider f-string instead of string join
     "FLY002",
     # Use a list comprehension to create a transformed list

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,5 @@
 cython>=0.28.4
 mypy
-types-certifi
 pre-commit
+ruff
+types-certifi

--- a/test/test_doctest_wrapper.py
+++ b/test/test_doctest_wrapper.py
@@ -33,9 +33,9 @@ def test_doctests():
         expected_failure_count = 6
 
     # if the below line fails, doctests have failed
-    assert (
-        failure_count == expected_failure_count
-    ), f"{failure_count} of the doctests failed"
+    assert failure_count == expected_failure_count, (
+        f"{failure_count} of the doctests failed"
+    )
 
 
 @pytest.mark.network

--- a/test/test_transformer.py
+++ b/test/test_transformer.py
@@ -592,8 +592,7 @@ def test_transformer__operations__scope_remarks():
     assert transformer.scope is None
     assert [op.scope for op in transformer.operations] == [
         "Engineering survey, topographic mapping.",
-        "Transformation of GDA94 coordinates that have been derived "
-        "through GNSS CORS.",
+        "Transformation of GDA94 coordinates that have been derived through GNSS CORS.",
         "Engineering survey, topographic mapping.",
     ]
     assert [str(op.remarks)[:5].strip() for op in transformer.operations] == [


### PR DESCRIPTION
This maintenance PR does the following:

- Replace Black with the Ruff formatter
- Replace isort with Ruff's "I" lint check
- Update the Ruff version in pre-commit, which changes a few source files
- Remove target-version from ruff configuration, since this is automatically evaluated
- Add ruff to requirements-dev.txt
- Update relevant excerpts of CONTRIBUTING.md with these changes