### PR TITLE
CI: Add 3.13 free-threading wheels

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -139,7 +139,6 @@ jobs:
       - name: Build wheels
         uses: pypa/cibuildwheel@v3.1.3
         env:
-          CIBW_SKIP: "pp*-win* pp31*"
           CIBW_ENABLE: cpython-freethreading
           CIBW_ARCHS: ${{ matrix.arch }}
           CIBW_ENVIRONMENT_LINUX:


### PR DESCRIPTION
Continuation from #1512 

 - [ ] Closes #xxxx
 - [ ] Tests added
 - [ ] Fully documented, including `history.rst` for all changes and `api/*.rst` for new API
