### PR TITLE
TST: Remove irrelevant test with modern PROJ versions

### DIFF
--- a/docs/history.rst
+++ b/docs/history.rst
@@ -9,6 +9,7 @@ Change Log
 - DEP: Add win_arm64 wheels
 - DEP: Add Python 3.13 free-threading wheels
 - DEP: Add Python 3.14 and 3.14 free-threading wheels
+- TST: Remove irrelevant test with modern PROJ versions
 
 3.7.1
 ------

--- a/test/test_transformer.py
+++ b/test/test_transformer.py
@@ -1310,27 +1310,6 @@ def test_transform_bounds__beyond_global_bounds():
     )
 
 
-@pytest.mark.parametrize(
-    "input_crs,input_bounds,expected_bounds",
-    [
-        (
-            "ESRI:102036",
-            (-180.0, -90.0, 180.0, 1.3),
-            (0, -116576599, 0, 0),
-        ),
-        ("ESRI:54026", (-180.0, -90.0, 180.0, 90.0), (0, -179545824, 0, 179545824)),
-    ],
-)
-def test_transform_bounds__ignore_inf(input_crs, input_bounds, expected_bounds):
-    crs = CRS(input_crs)
-    transformer = Transformer.from_crs(crs.geodetic_crs, crs, always_xy=True)
-    assert_almost_equal(
-        transformer.transform_bounds(*input_bounds),
-        expected_bounds,
-        decimal=0,
-    )
-
-
 def test_transform_bounds__ignore_inf_geographic():
     crs_wkt = (
         'PROJCS["Interrupted_Goode_Homolosine",'


### PR DESCRIPTION
@snowman2 I'm not sure if this is what you mean, but I understood your last comment to mean that updating this pyproj test for PROJ 9.6.2 would result in not actually testing anything in pyproj since all the values are now valid. So in this PR I've removed the test.

Release this as an rc1?

 - [x] Closes #1513 
 - [x] Tests added
 - [x] Fully documented, including `history.rst` for all changes and `api/*.rst` for new API
