### PR TITLE
fix TransformerGroup crash when proj_normalize_for_visualization() returns NULL

### DIFF
--- a/test/test_transformer.py
+++ b/test/test_transformer.py
@@ -1587,8 +1587,14 @@ def test_transformer_group_allow_superseded_filter():
 def test_transformer_group_allow_superseded_always_xy():
     """Test that TransformerGroup works with both allow_superseded and always_xy."""
     # This combination used to fail with "Input is not a transformation" error
+    # because proj_normalize_for_visualization() returns NULL for certain
+    # concatenated operations (e.g., EPSG:8047).
     group = TransformerGroup(4230, 4326, allow_superseded=True, always_xy=True)
     assert len(group.transformers) >= 1
+    # Operations that cannot be normalized for visualization should be in
+    # unavailable_operations, not silently dropped
+    total_ops = len(group.transformers) + len(group.unavailable_operations)
+    assert total_ops >= 1
 
 
 def test_transformer_group_crs_extent_use_none():


### PR DESCRIPTION
Fix bug in TransformerGroup where it crashes when `proj_normalize_for_visualization()` returns `NULL`.

This issue became visible when using both `allow_superseded=True` and `always_xy=True`, which causes the superseded concatenated transformation [ED50 to WGS 84 (15) (EPSG:8047)](https://epsg.org/concatenated-operation_8047/ED50-to-WGS-84-15.html?sessionkey=0beyllj5ob) to be added to the list. Since the two sub-steps of the transformation do not have intersecting extents, PROJ fails to perform the axis swap, and `proj_normalize_for_visualization()` returns `NULL`.

```python 
from pyproj.transformer import TransformerGroup
TransformerGroup("EPSG:4230", "EPSG:4326", allow_superseded=True, always_xy=True).transformers
```

The fix:
- In `_set_always_xy()`: Check for `NULL` return and set `self.projobj` to `NULL` before raising `ProjError`, allowing the original pointer to remain valid
- In `_TransformerGroup.__init__()`: Catch `ProjError` from `_from_pj()` and add the operation to `unavailable_operations` instead of crashing

Operations that cannot be normalized for visualization (e.g., certain concatenated operations with non-overlapping step extents) are now properly tracked in `unavailable_operations` rather than causing a crash.

**Note:**
I created a PR to PROJ (now merged to main) where the extent validation is skipped for axis-swapping operations. This is safe because the axis-swap operations added by `normalizeForVisualization()` have no spatial effect—they only reorder coordinates—so the extent check can be safely skipped.

See: https://github.com/OSGeo/PROJ/pull/4632

Fixes #1464

 - ✅ Closes #1464 
 - ✅ Tests added

