### PR TITLE
Fix tests for PROJ 9.7.0 and newer 

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -14,7 +14,7 @@ _NETWORK_ENABLED = pyproj.network.is_network_enabled()
 PROJ_LOOSE_VERSION = version.parse(pyproj.__proj_version__)
 PROJ_GTE_941 = PROJ_LOOSE_VERSION >= version.parse("9.4.1")
 PROJ_GTE_95 = PROJ_LOOSE_VERSION >= version.parse("9.5.0")
-PROJ_GTE_97 = PROJ_LOOSE_VERSION >= version.parse("9.7.0")
+PROJ_GTE_971 = PROJ_LOOSE_VERSION >= version.parse("9.7.1")
 
 
 def unset_data_dir():

--- a/test/crs/test_crs.py
+++ b/test/crs/test_crs.py
@@ -20,7 +20,7 @@ from pyproj.crs.enums import CoordinateOperationType, DatumType
 from pyproj.enums import ProjVersion, WktVersion
 from pyproj.exceptions import CRSError
 from pyproj.transformer import TransformerGroup
-from test.conftest import PROJ_GTE_97, PROJ_GTE_941, assert_can_pickle, grids_available
+from test.conftest import PROJ_GTE_941, PROJ_GTE_971, assert_can_pickle, grids_available
 
 
 class CustomCRS:
@@ -418,11 +418,11 @@ def test_datum():
 
 def test_datum_horizontal():
     # EPSG:5972 is a Norwegian compound CRS
-    # In PROJ < 9.7.0, it uses the generic ETRS89 ensemble (same as EPSG:25832)
-    # In PROJ >= 9.7.0 (EPSG v12.022+), it uses the
+    # In PROJ < 9.7.1, it uses the generic ETRS89 ensemble (same as EPSG:25832)
+    # In PROJ >= 9.7.1 (EPSG v12.022+), it uses the
     # Norway-specific ETRS89-NOR realization
     crs_5972 = CRS.from_epsg(5972)
-    if PROJ_GTE_97:
+    if PROJ_GTE_971:
         # Test against ETRS89-NOR [EUREF89] / UTM zone 32N
         crs_11022 = CRS.from_epsg(11022)
         assert crs_5972.datum is not None
@@ -585,9 +585,9 @@ def test_sub_crs():
     sub_crs_list = crs.sub_crs_list
     assert len(sub_crs_list) == 2
     # First sub-CRS should be a projected CRS (UTM zone 32N)
-    # In PROJ < 9.7.0, it's EPSG:25832 (ETRS89 / UTM zone 32N)
-    # In PROJ >= 9.7.0 (EPSG v12.022+), it's EPSG:11022 (ETRS89-NOR / UTM zone 32N)
-    if PROJ_GTE_97:
+    # In PROJ < 9.7.1, it's EPSG:25832 (ETRS89 / UTM zone 32N)
+    # In PROJ >= 9.7.1 (EPSG v12.022+), it's EPSG:11022 (ETRS89-NOR / UTM zone 32N)
+    if PROJ_GTE_971:
         assert sub_crs_list[0].is_projected
         assert sub_crs_list[0] == CRS.from_epsg(11022)
     else:


### PR DESCRIPTION
## Fix tests to pass for PROJ 9.7.0+ EPSG database changes

 - ✅ Closes #1553 

### Description

This PR updates two tests (`test_datum_horizontal` and `test_sub_crs`) that fail with PROJ 9.7.0+ due to changes in the EPSG database.

### Background

Starting with PROJ 9.7.0 (which includes EPSG v12.022), the EPSG database introduced **national realizations of ETRS89** to better reflect how countries actually implement the European Terrestrial Reference System. 

Norway uses **ETRS89-NOR** (also known as EUREF89), which is a specific national realization tied to epoch 1995. This is technically more correct than using the generic ETRS89 ensemble, as Norway's coordinates are tied to a specific realization.

### What changed in PROJ 9.7.0

For Norwegian CRS definitions:

| | PROJ < 9.7.0 | PROJ >= 9.7.0 |
|---|---|---|
| EPSG:5972 | ETRS89 ensemble (EPSG:6258) | ETRS89-NOR (EPSG:1407) |
| EPSG:5972 horizontal sub-CRS | EPSG:25832 (ETRS89 / UTM zone 32N) | EPSG:11022 (ETRS89-NOR / UTM zone 32N) |

Similar changes have been made for other Nordic countries (Denmark, Sweden, Finland) and will likely continue for other nations.

### Changes

- Added `PROJ_GTE_97` version check constant in `test/conftest.py`
- Updated `test_datum_horizontal` to test against the appropriate datum based on PROJ version
- Updated `test_sub_crs` to test against the appropriate projected CRS (EPSG:25832 or EPSG:11022) based on PROJ version

