### PR TITLE
docs: added windows specfic intructions for building documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -120,6 +120,8 @@ You can build the documentation locally to see how your changes will look.
 * Build the docs: ``make docs``
 * Or, to build and open in a browser: ``make docs-browser``
 
+**On Windows:** Use ``make html`` instead of ``make docs``. Also ensure you have installed the documentation requirements with ``pip install -r requirements-docs.txt`` before building.
+
 ## Tests
 Unit tests are the lifeblood of the project, as it ensures that we can continue to add and
 change the code and stay confident that things have not broken. Running the tests requires

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -120,7 +120,7 @@ You can build the documentation locally to see how your changes will look.
 * Build the docs: ``make docs``
 * Or, to build and open in a browser: ``make docs-browser``
 
-**On Windows:** Use ``make html`` instead of ``make docs``. Also ensure you have installed the documentation requirements with ``pip install -r requirements-docs.txt`` before building.
+**On Windows:** Use ``make -C docs html`` instead of ``make docs``. Also ensure you have installed the documentation requirements with ``pip install --group docs`` before building.
 
 ## Tests
 Unit tests are the lifeblood of the project, as it ensures that we can continue to add and


### PR DESCRIPTION
Fixes #1491

Added Windows-specific instructions for building documentation:
- Note to use `make html` instead of `make docs`
- Clarify that `requirements-docs.txt` needs to be installed

This helps Windows users who may not be familiar with the Unix make commands.