### PR TITLE
fix tiny typo in docstring

### DIFF
--- a/pyproj/crs/crs.py
+++ b/pyproj/crs/crs.py
@@ -526,7 +526,7 @@ class CRS:
 
         Parameters
         ----------
-        proj_dict : str
+        proj_dict : dict
             PROJ params in dict format.
 
         Returns


### PR DESCRIPTION
Fixes a tiny typo in the docstring for `CRS.from_dict`

Thanks so much for building and maintaining this library! It's a big part of the graphics backend I'm building for [Starplot](https://github.com/steveberardi/starplot)