### PR TITLE
Use dependency-groups (PEP 735) instead of requirements files

### DIFF
--- a/.github/workflows/build_docs.yaml
+++ b/.github/workflows/build_docs.yaml
@@ -33,8 +33,7 @@ jobs:
       - name: Install and Build
         shell: bash
         run: |
-          micromamba run -n docs python -m pip install -e .
-          micromamba run -n docs python -m pip install -r requirements-docs.txt
+          micromamba run -n docs python -m pip install -e . --group docs
           micromamba run -n docs sphinx-build -b html docs/ docs/_build/
 
       - name: Deploy 🚀

--- a/.github/workflows/test_proj_latest.yaml
+++ b/.github/workflows/test_proj_latest.yaml
@@ -42,8 +42,7 @@ jobs:
         run: |
           python -V
           python -m pip install --upgrade --pre --only-binary :all: -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple cython
-          python -m pip install -e .
-          python -m pip install -r requirements-test.txt
+          python -m pip install -e . --group test
           pyproj -v
 
       - name: Test

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -27,7 +27,7 @@ jobs:
       - uses: pre-commit/action@v3.0.1
       - name: Install mypy
         run: |
-          python -m pip install mypy types-certifi
+          python -m pip install --group typing
       - name: mypy
         run: |
           mypy pyproj
@@ -73,9 +73,7 @@ jobs:
           python${{ matrix.python-version }} -m venv testenv
           . testenv/bin/activate
           python -m pip install --upgrade pip
-          python -m pip install -r requirements-dev.txt
-          python -m pip install -e .
-          python -m pip install -r requirements-test.txt
+          python -m pip install -e . --group dev
 
       - name: Test
         shell: bash
@@ -137,12 +135,7 @@ jobs:
       - name: Install Env
         shell: bash
         run: |
-          if [ "${{ matrix.python-implementation }}" = "pypy" ]; then
-            sed -i.bak '/xarray/d' requirements-test.txt;
-            sed -i.bak '/pandas/d' requirements-test.txt;
-          fi;
-          micromamba run -n test python -m pip install -e .
-          micromamba run -n test python -m pip install -r requirements-test.txt
+          micromamba run -n test python -m pip install -e . --group test
 
       - name: Check and Log Environment
         shell: bash
@@ -155,7 +148,7 @@ jobs:
         shell: bash
         if: matrix.python-implementation == 'python'
         run: |
-          micromamba run -n test python -m pip install pylint
+          micromamba run -n test python -m pip install --group lint
 
       - name: pylint
         shell: bash
@@ -196,7 +189,7 @@ jobs:
         shell: bash
         if: contains(matrix.os, 'ubuntu') && matrix.python-implementation == 'python'
         run: |
-          micromamba run -n test python -m pip install -r requirements-docs.txt
+          micromamba run -n test python -m pip install --group docs
           micromamba run -n test sphinx-build -b html docs/ docs/_build/
           micromamba run -n test sphinx-build -b man docs/ docs/_build/
 

--- a/.gitignore
+++ b/.gitignore
@@ -91,6 +91,9 @@ celerybeat-schedule
 # dotenv
 .env
 
+# uv env
+uv.lock
+
 # virtualenv
 .venv
 venv/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,7 +86,7 @@ environments. Our recommended setup for contributing is:
     ```
 * Activate our new development environment ``conda activate devel`` on Mac/Linux or
   ``activate devel`` on Windows.
-* Install development requirements ``python -m pip install -r requirements-dev.txt``
+* Install development requirements ``python -m pip install --group dev``
 * Make an editable install of pyproj by running ``python -m pip install -e .``
 * Setup pre-commit hooks ``pre-commit install``
 
@@ -126,7 +126,7 @@ change the code and stay confident that things have not broken. Running the test
 ``pytest``, which is easily available through ``conda`` or ``pip``. It was also installed if you made our default ``devel`` environment.
 
 ### Running Tests
-Running the tests can be done by running ``python -m pytest``. Make sure you install the test requirements before running the tests ``python -m pip install -r requirements-test.txt``.
+Running the tests can be done by running ``python -m pytest``. Make sure you install the test requirements before running the tests ``python -m pip install --group test``.
 
 Running the whole test suite isn't that slow, but can be a burden if you're working on just
 one module or a specific test. It is easy to run tests on a single directory:

--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ test-coverage:  ## run tests and generate coverage report
 	py.test --cov-report term-missing --cov=pyproj -v -s
 
 install-docs: ## Install requirements for building documentation
-	python -m pip install -r requirements-docs.txt
+	python -m pip install --group docs
 
 docs: ## generate Sphinx HTML documentation, including API docs
 	$(MAKE) -C docs clean
@@ -79,7 +79,6 @@ install: clean ## install the package to the active Python's site-packages
 	python -m pip install .
 
 install-dev: clean ## install development version to active Python's site-packages
-	python -m pip install -r requirements-dev.txt
+	python -m pip install --group dev
 	pre-commit install
-	python -m pip install -r requirements-test.txt
 	PYPROJ_FULL_COVERAGE=YES python -m pip install -e .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,38 @@ changelog = "https://pyproj4.github.io/pyproj/stable/history.html"
 [project.scripts]
 pyproj = "pyproj.__main__:main"
 
+[dependency-groups]
+dev = [
+    "cython>=0.28.4",
+    "pre-commit",
+    "setuptools",
+    {include-group = "lint"},
+    {include-group = "test"},
+    {include-group = "typing"},
+]
+docs = [
+    "furo>=2022.6",
+    "sphinx",
+    "sphinx-argparse",
+]
+lint = [
+    "pylint",
+    "ruff",
+]
+test = [
+    "numpy",
+    "packaging",
+    "pandas; python_version<'3.12' and implementation_name!='pypi'",
+    "pytest>3.6",
+    "pytest-cov",
+    "shapely; python_version<'3.12'",
+    "xarray; python_version<'3.12' and implementation_name!='pypi'",
+]
+typing = [
+    "mypy",
+    "types-certifi",
+]
+
 [tool.setuptools]
 zip-safe = false # https://mypy.readthedocs.io/en/stable/installed_packages.html
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,11 +78,11 @@ lint = [
 test = [
     "numpy",
     "packaging",
-    "pandas; python_version<'3.12' and implementation_name!='pypi'",
+    "pandas",
     "pytest>3.6",
     "pytest-cov",
-    "shapely; python_version<'3.12'",
-    "xarray; python_version<'3.12' and implementation_name!='pypi'",
+    "shapely",
+    "xarray",
 ]
 typing = [
     "mypy",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,0 @@
-cython>=0.28.4
-mypy
-pre-commit
-ruff
-types-certifi

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,3 +1,0 @@
-furo>=2022.6
-sphinx
-sphinx-argparse

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,7 +1,0 @@
-packaging
-pytest>3.6
-pytest-cov
-numpy
-pandas; python_version<'3.12'
-shapely; python_version<'3.12'
-xarray; python_version<'3.12'


### PR DESCRIPTION
This PR uses dependency groups ([PEP 735](https://peps.python.org/pep-0735/)), which is a standard Python feature supported by modern pip frontends.

This feature replaces the need for `requirements-*.txt` files, which are removed.