### PR TITLE
Update and fix linting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,18 +3,18 @@ default_language_version:
 
 repos:
     -   repo: https://github.com/pre-commit/pre-commit-hooks
-        rev: v4.5.0
+        rev: v6.0.0
         hooks:
         -   id: check-yaml
         -   id: end-of-file-fixer
         -   id: trailing-whitespace
     -   repo: https://github.com/asottile/blacken-docs
-        rev: 1.16.0
+        rev: 1.20.0
         hooks:
         -   id: blacken-docs
             args: [--skip-errors]
     -   repo: https://github.com/pycqa/flake8
-        rev: 7.0.0
+        rev: 7.3.0
         hooks:
         -   id: flake8
             additional_dependencies: [flake8-comprehensions>=3.1.0]
@@ -25,12 +25,12 @@ repos:
             - file
             args: [--append-config=flake8/cython.cfg]
     -   repo: https://github.com/codespell-project/codespell
-        rev: v2.2.6
+        rev: v2.4.2
         hooks:
         -   id: codespell
             args: [--uri-ignore-words-list, buildd]
     -   repo: https://github.com/astral-sh/ruff-pre-commit
-        rev: v0.11.10
+        rev: v0.15.19
         hooks:
         - id: ruff-check
         - id: ruff-format

--- a/docs/build_crs.rst
+++ b/docs/build_crs.rst
@@ -155,7 +155,6 @@ The PROJ string is quite lossy in this example, so it is not provided.
     from pyproj.crs.coordinate_system import Cartesian2DCS, VerticalCS
     from pyproj.crs.coordinate_operation import LambertConformalConic2SPConversion
 
-
     vertcrs = VerticalCRS(
         name="NAVD88 height",
         datum="North American Vertical Datum 1988",

--- a/pyproj/transformer.py
+++ b/pyproj/transformer.py
@@ -428,7 +428,7 @@ class TransformerLocal(threading.local):
 
 class Transformer:
     """
-    The Transformer class is for facilitating re-using
+    The Transformer class is for facilitating reusing
     transforms without needing to re-create them. The goal
     is to make repeated transforms faster.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -140,6 +140,8 @@ ignore = [
     "B028",
     # Unused `noqa` directive # Only work if ruff is the solve linter/formatter
     "RUF100",
+    # Unpacked variable is never used
+    "RUF059",
     # `zip()` without an explicit `strict=` parameter
     "B905",
     # Only simple default values allowed for typed arguments
@@ -153,7 +155,9 @@ ignore = [
     # Consider f-string instead of string join
     "FLY002",
     # Use a list comprehension to create a transformed list
-    "PERF401"
+    "PERF401",
+    # Invalid rule code in `# noqa`; used by pylint
+    "RUF102",
 
 ]
 

--- a/test/test_aoi.py
+++ b/test/test_aoi.py
@@ -42,5 +42,5 @@ def test_not_intersects():
     ],
 )
 def test_null_input(aoi_class, input):
-    with pytest.raises(ValueError, match="NaN or None values are not allowed."):
+    with pytest.raises(ValueError, match=r"NaN or None values are not allowed."):
         aoi_class(*input)

--- a/test/test_sync.py
+++ b/test/test_sync.py
@@ -178,7 +178,7 @@ def test_download_resource_file__bad_sha256sum(urlretrieve_mock, tmp_path):
         local_path.touch()
 
     urlretrieve_mock.side_effect = dummy_urlretrieve
-    with pytest.raises(RuntimeError, match="SHA256 mismatch: test_file.txt"):
+    with pytest.raises(RuntimeError, match=r"SHA256 mismatch: test_file.txt"):
         _download_resource_file(
             file_url="test_url",
             short_name="test_file.txt",

--- a/test/test_transformer.py
+++ b/test/test_transformer.py
@@ -239,7 +239,7 @@ def test_2d_with_time_itransform_original_crs_obs2():
 def test_itransform_time_3rd_invalid():
     with (
         pytest.warns(FutureWarning),
-        pytest.raises(ValueError, match="'time_3rd' is only valid for 3 coordinates."),
+        pytest.raises(ValueError, match=r"'time_3rd' is only valid for 3 coordinates."),
     ):
         list(
             itransform(
@@ -251,7 +251,7 @@ def test_itransform_time_3rd_invalid():
         )
     with (
         pytest.warns(FutureWarning),
-        pytest.raises(ValueError, match="'time_3rd' is only valid for 3 coordinates."),
+        pytest.raises(ValueError, match=r"'time_3rd' is only valid for 3 coordinates."),
     ):
         list(itransform(7789, 8401, [(3496737.2679, 743254.4507)], time_3rd=True))
 
@@ -858,7 +858,7 @@ def test_transformer__only_best():
     if not grids_available("ca_nrc_ntv2_0.tif"):
         with pytest.raises(
             ProjError,
-            match="Grid ca_nrc_ntv2_0.tif is not available.",
+            match=r"Grid ca_nrc_ntv2_0.tif is not available.",
         ):
             transformer.transform(60, -100, errcheck=True)
 


### PR DESCRIPTION
It seems that the linting job fails, possibly due to older versions of dependencies. This updates pre-commit deps and fixes any issues. A few ruff rules are ignored, they can be revised later.