### PR TITLE
DOC: document late-binding behavior of Transformer serialization methods

### DIFF
--- a/docs/history.rst
+++ b/docs/history.rst
@@ -16,6 +16,7 @@ Latest
 - BUG: Clear CONTEXT_THREAD_KEY when destroying PJ_CONTEXT (pull #1541)
 - BUG: Default skew angle for CF grid mapping oblique mercator to 90 (issue #1506)
 - BLD: update build-time dependencies
+- DOC: Document late-binding behavior of :meth:`pyproj.transformer.Transformer.to_json` and :meth:`pyproj.transformer.Transformer.to_wkt` returning ``None`` (and :meth:`pyproj.transformer.Transformer.to_json_dict` raising ``TypeError``) for transformers built with :meth:`pyproj.transformer.Transformer.from_crs` (issue #1549)
 
 3.7.2
 -----

--- a/pyproj/transformer.py
+++ b/pyproj/transformer.py
@@ -1247,8 +1247,22 @@ class Transformer:
 
         Returns
         -------
-        str:
-            The WKT string.
+        str or None:
+            The WKT string, or ``None`` if the transformation has not been
+            selected yet (see Notes).
+
+        Notes
+        -----
+        A :class:`Transformer` built with :meth:`Transformer.from_crs` can be
+        "late-binding": PROJ defers selecting a concrete transformation until
+        :meth:`Transformer.transform` is called with coordinates. Until then there
+        is no operation to serialize and this method returns ``None``
+        (``transformer.description`` reports
+        ``"unavailable until proj_trans is called"``).
+        The same workarounds as :meth:`to_json` apply: call
+        :meth:`get_last_used_operation` after :meth:`transform`, or build a
+        :class:`TransformerGroup` and call ``to_wkt`` on one of its
+        ``.transformers``.
         """
         return self._transformer.to_wkt(version=version, pretty=pretty)
 
@@ -1267,8 +1281,34 @@ class Transformer:
 
         Returns
         -------
-        str:
-            The JSON string.
+        str or None:
+            The JSON string, or ``None`` if the transformation has not been
+            selected yet (see Notes).
+
+        Notes
+        -----
+        A :class:`Transformer` built with :meth:`Transformer.from_crs` can be
+        "late-binding": PROJ defers selecting a concrete transformation until
+        :meth:`Transformer.transform` is called with coordinates. Until then there
+        is no operation to serialize and this method returns ``None``
+        (``transformer.description`` reports
+        ``"unavailable until proj_trans is called"``).
+        To serialize the operation that was actually used, transform a coordinate
+        and then use :meth:`get_last_used_operation` (PROJ 9.1+)::
+
+            transformer = Transformer.from_crs(
+                "EPSG:4258", "EPSG:32633", always_xy=True
+            )
+            transformer.transform(15, 60)
+            transformer.get_last_used_operation().to_json()
+
+        Alternatively, use :class:`TransformerGroup` to obtain the candidate
+        operations up front and serialize one of them::
+
+            from pyproj.transformer import TransformerGroup
+
+            group = TransformerGroup("EPSG:4258", "EPSG:32633")
+            group.transformers[0].to_json()
         """
         return self._transformer.to_json(pretty=pretty, indentation=indentation)
 
@@ -1282,6 +1322,17 @@ class Transformer:
         -------
         dict:
             The JSON dictionary.
+
+        Notes
+        -----
+        A :class:`Transformer` built with :meth:`Transformer.from_crs` can be
+        "late-binding": PROJ defers selecting a concrete transformation until
+        :meth:`Transformer.transform` is called with coordinates. While the
+        transformation is unselected the underlying JSON is ``None``, so this
+        method raises ``TypeError`` ("the JSON object must be str, bytes or
+        bytearray, not NoneType"). Use the same workarounds as :meth:`to_json`
+        (call :meth:`get_last_used_operation` after :meth:`transform`, or use a
+        :class:`TransformerGroup`) and call ``to_json_dict`` on the operation.
         """
         return self._transformer.to_json_dict()
 


### PR DESCRIPTION
## Summary

A `Transformer` built with `Transformer.from_crs(...)` is late-binding: PROJ does not select a concrete operation until `transform()` is called with coordinates. Until then `to_json()` and `to_wkt()` return `None`, and `to_json_dict()` raises `TypeError: the JSON object must be str, bytes or bytearray, not NoneType` (#1549). The docstrings did not mention this, so the `None` and the `TypeError` look like bugs.

## Changes

- Document the late-binding behavior in the `to_json`, `to_wkt`, and `to_json_dict` docstrings, including the two ways to obtain a serializable operation: call `get_last_used_operation()` after `transform()` (PROJ 9.1+), or build a `TransformerGroup` and serialize one of its candidate operations.
- Note the asymmetry in this state: `to_json` / `to_wkt` return `None` while `to_json_dict` raises `TypeError`.
- Qualify the `Returns` of `to_json` / `to_wkt` as `str or None`.
- Add a `docs/history.rst` entry.

Docs only, no behavior change.

Closes #1549
