### PR TITLE
perf: improve single point transform and remove warning from numpy scalars

### DIFF
--- a/docs/history.rst
+++ b/docs/history.rst
@@ -17,6 +17,7 @@ Latest
 - BUG: Clear CONTEXT_THREAD_KEY when destroying PJ_CONTEXT (pull #1541)
 - BUG: Default skew angle for CF grid mapping oblique mercator to 90 (issue #1506)
 - BLD: update build-time dependencies
+- PERF: Optimize single point transformations and remove typecast warning (issue #1309)
 
 3.7.2
 -----

--- a/pyproj/_compat.pxd
+++ b/pyproj/_compat.pxd
@@ -1,6 +1,19 @@
 cdef str cstrdecode(const char *instring)
 cpdef bytes cstrencode(str pystr)
 
+
+cdef inline bint _is_scalar(object value):
+    """
+    Check whether ``value`` is a single number that the point-optimized
+    functions can consume.
+
+    This must be called *before* any implicit ``double x = value`` conversion.
+    """
+    if isinstance(value, (float, int)):
+        return True
+    return getattr(value, "ndim", -1) == 0
+
+
 IF CTE_PYTHON_IMPLEMENTATION == "CPython":
     from cpython cimport array
     cdef array.array empty_array(int npts)

--- a/pyproj/_geod.pyi
+++ b/pyproj/_geod.pyi
@@ -38,7 +38,7 @@ class Geod:
         dist: float,
         radians: bool = False,
         return_back_azimuth: bool = True,
-    ) -> tuple[float, float, float]: ...
+    ) -> tuple[float, float, float] | None: ...
     def _inv(
         self,
         lons1: Any,
@@ -56,7 +56,7 @@ class Geod:
         lats2: float,
         radians: bool = False,
         return_back_azimuth: bool = False,
-    ) -> tuple[float, float, float]: ...
+    ) -> tuple[float, float, float] | None: ...
     def _inv_or_fwd_intermediate(
         self,
         lon1: float,

--- a/pyproj/_geod.pyx
+++ b/pyproj/_geod.pyx
@@ -3,7 +3,7 @@ include "base.pxi"
 cimport cython
 from libc.math cimport ceil, isnan, round
 
-from pyproj._compat cimport cstrencode, empty_array
+from pyproj._compat cimport _is_scalar, cstrencode, empty_array
 
 import math
 from collections import namedtuple
@@ -190,7 +190,19 @@ cdef class Geod:
         of a terminus point given an initial point longitude and latitude, plus
         forward azimuth and distance.
         if radians=True, lons/lats are radians instead of degrees.
+
+        Returns None if the inputs are not scalars, so that the caller can
+        fall back to the buffer-based array path.
         """
+        # The type checks must come before the conversions below
+        if (
+            not _is_scalar(lon1in)
+            or not _is_scalar(lat1in)
+            or not _is_scalar(az1in)
+            or not _is_scalar(s12in)
+        ):
+            return None
+
         cdef:
             double plon2
             double plat2
@@ -199,13 +211,6 @@ cdef class Geod:
             double lat1 = lat1in
             double az1 = az1in
             double s12 = s12in
-
-        # We do the type-checking internally here due to automatically
-        # casting length-1 arrays to float that we don't want to return scalar for.
-        # Ex: float(np.array([0])) works and we don't want to accept numpy arrays
-        for x_in in (lon1in, lat1in, az1in, s12in):
-            if not isinstance(x_in, (float, int)):
-                raise TypeError("Scalar input is required for point based functions")
 
         with nogil:
             if radians:
@@ -318,7 +323,19 @@ cdef class Geod:
         inverse transformation - return forward and back azimuth, plus distance
         between an initial and terminus lat/lon pair.
         if radians=True, lons/lats are radians instead of degree
+
+        Returns None if the inputs are not scalars, so that the caller can
+        fall back to the buffer-based array path.
         """
+        # The type checks must come before the conversions below
+        if (
+            not _is_scalar(lon1in)
+            or not _is_scalar(lat1in)
+            or not _is_scalar(lon2in)
+            or not _is_scalar(lat2in)
+        ):
+            return None
+
         cdef:
             double pazi1
             double pazi2
@@ -327,13 +344,6 @@ cdef class Geod:
             double lat1 = lat1in
             double lon2 = lon2in
             double lat2 = lat2in
-
-        # We do the type-checking internally here due to automatically
-        # casting length-1 arrays to float that we don't want to return scalar for.
-        # Ex: float(np.array([0])) works and we don't want to accept numpy arrays
-        for x_in in (lon1in, lat1in, lon2in, lat2in):
-            if not isinstance(x_in, (float, int)):
-                raise TypeError("Scalar input is required for point based functions")
 
         with nogil:
             if radians:

--- a/pyproj/_transformer.pyi
+++ b/pyproj/_transformer.pyi
@@ -1,4 +1,3 @@
-import numbers
 from array import array
 from typing import Any, NamedTuple
 
@@ -111,14 +110,14 @@ class _Transformer(Base):
     ) -> None: ...
     def _transform_point(
         self,
-        inx: numbers.Real,
-        iny: numbers.Real,
-        inz: numbers.Real,
-        intime: numbers.Real,
+        inx: Any,
+        iny: Any,
+        inz: Any,
+        intime: Any,
         direction: TransformDirection | str,
         radians: bool,
         errcheck: bool,
-    ) -> None: ...
+    ) -> tuple[float, ...] | None: ...
     def _transform_sequence(
         self,
         stride: int,

--- a/pyproj/_transformer.pyx
+++ b/pyproj/_transformer.pyx
@@ -8,7 +8,7 @@ import re
 import warnings
 from collections import namedtuple
 
-from pyproj._compat cimport cstrencode
+from pyproj._compat cimport _is_scalar, cstrencode
 from pyproj._context cimport _clear_proj_error, _get_proj_error, pyproj_context_create
 from pyproj._crs cimport (
     _CRS,
@@ -862,37 +862,31 @@ cdef class _Transformer(Base):
     ):
         """
         Optimized to transform a single point between two coordinate systems.
+
+        Returns None if the inputs are not scalars, so that the caller can
+        fall back to the buffer-based array path.
         """
+        # The type checks must come before the conversions below
+        if not _is_scalar(inx) or not _is_scalar(iny):
+            return None
+        if inz is not None and not _is_scalar(inz):
+            return None
+        if intime is not None and not _is_scalar(intime):
+            return None
+
         cdef:
             double coord_x = inx
             double coord_y = iny
-            double coord_z = 0
-            double coord_t = HUGE_VAL
-            tuple expected_numeric_types = (int, float)
-
-        # We do the type-checking internally here due to automatically
-        # casting length-1 arrays to float that we don't want to return scalar for.
-        # Ex: float(np.array([0])) works and we don't want to accept numpy arrays
-        if not isinstance(inx, expected_numeric_types):
-            raise TypeError("Scalar input expected for x")
-        if not isinstance(iny, expected_numeric_types):
-            raise TypeError("Scalar input expected for y")
-        if inz is not None:
-            if not isinstance(inz, expected_numeric_types):
-                raise TypeError("Scalar input expected for z")
-            coord_z = inz
-        if intime is not None:
-            if not isinstance(intime, expected_numeric_types):
-                raise TypeError("Scalar input expected for t")
-            coord_t = intime
+            double coord_z = 0 if inz is None else inz
+            double coord_t = HUGE_VAL if intime is None else intime
 
         cdef tuple return_data
         if self.id == "noop":
-            return_data = (inx, iny)
+            return_data = (coord_x, coord_y)
             if inz is not None:
-                return_data += (inz,)
+                return_data += (coord_z,)
             if intime is not None:
-                return_data += (intime,)
+                return_data += (coord_t,)
             return return_data
 
         cdef:

--- a/pyproj/geod.py
+++ b/pyproj/geod.py
@@ -300,19 +300,18 @@ class Geod(_Geod):
         scalar or array:
             Back azimuth(s) or Forward azimuth(s)
         """
-        try:
-            # Fast-path for scalar input, will raise if invalid types are input
-            # and we can fallback below
-            return self._fwd_point(
-                lons,
-                lats,
-                az,
-                dist,
-                radians=radians,
-                return_back_azimuth=return_back_azimuth,
-            )
-        except TypeError:
-            pass
+        # Fast-path for scalar input; returns None for non-scalar input
+        # and we fall back below
+        point_data = self._fwd_point(
+            lons,
+            lats,
+            az,
+            dist,
+            radians=radians,
+            return_back_azimuth=return_back_azimuth,
+        )
+        if point_data is not None:
+            return point_data
 
         # process inputs, making copies that support buffer API.
         inx, x_data_type = _copytobuffer(lons, inplace=inplace)
@@ -392,19 +391,18 @@ class Geod(_Geod):
             Distance(s) between initial and terminus point(s)
             in meters
         """
-        try:
-            # Fast-path for scalar input, will raise if invalid types are input
-            # and we can fallback below
-            return self._inv_point(
-                lons1,
-                lats1,
-                lons2,
-                lats2,
-                radians=radians,
-                return_back_azimuth=return_back_azimuth,
-            )
-        except TypeError:
-            pass
+        # Fast-path for scalar input; returns None for non-scalar input
+        # and we fall back below
+        point_data = self._inv_point(
+            lons1,
+            lats1,
+            lons2,
+            lats2,
+            radians=radians,
+            return_back_azimuth=return_back_azimuth,
+        )
+        if point_data is not None:
+            return point_data
 
         # process inputs, making copies that support buffer API.
         inx, x_data_type = _copytobuffer(lons1, inplace=inplace)

--- a/pyproj/transformer.py
+++ b/pyproj/transformer.py
@@ -940,19 +940,18 @@ class Transformer:
         '33  98'
 
         """
-        try:
-            # function optimized for point data
-            return self._transformer._transform_point(
-                inx=xx,
-                iny=yy,
-                inz=zz,
-                intime=tt,
-                direction=direction,
-                radians=radians,
-                errcheck=errcheck,
-            )
-        except TypeError:
-            pass
+        # function optimized for point data; returns None for non-scalar input
+        point_data = self._transformer._transform_point(
+            inx=xx,
+            iny=yy,
+            inz=zz,
+            intime=tt,
+            direction=direction,
+            radians=radians,
+            errcheck=errcheck,
+        )
+        if point_data is not None:
+            return point_data
         # process inputs, making copies that support buffer API.
         inx, x_data_type = _copytobuffer(xx, inplace=inplace)
         iny, y_data_type = _copytobuffer(yy, inplace=inplace)


### PR DESCRIPTION
Change from a try/except raise case for numpy array vs scalar checking to a `_is_scalar` check that also removes the numpy warning cases without any cutout needed for numpy specifically. This is both faster and cleaner. I think that before I was potentially trying two things that degraded performance: `isinstance(x, numbers.Real)` which goes back out to Python rather than Cython being able to check in C against float/int which we have now, and putting it after the type-cast cdef declarations (now the is_scalar check comes before that).

<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Closes #1309
 - [x] Fully documented, including `history.rst` for all changes and `api/*.rst` for new API
