### PR TITLE
PERF: fast paths for CRS equality and hashing

### DIFF
--- a/docs/history.rst
+++ b/docs/history.rst
@@ -13,6 +13,8 @@ Latest
 - ENH: Added grid_check kwarg to :class:`pyproj.transformer.TransformerGroup` mirroring PROJ CLI ``--grid-check``
 - ENH: Added :class:`pyproj.enums.GridAvailabilityUse` enum for TransformerGroup ``grid_check`` kwarg
 - ENH: Added always_xy kwarg to :meth:`pyproj.transformer.Transformer.from_pipeline`
+- PERF: Speed up CRS comparisons with short-circuit and caching of results
+- PERF: Cache the result of ``hash(CRS)``
 - DOC: Update fiona CRS compatibility for fiona 1.9+ (issue #1360)
 - BUG: Clear CONTEXT_THREAD_KEY when destroying PJ_CONTEXT (pull #1541)
 - BUG: Default skew angle for CF grid mapping oblique mercator to 90 (issue #1506)

--- a/pyproj/crs/crs.py
+++ b/pyproj/crs/crs.py
@@ -75,7 +75,10 @@ _COMPARISON_CACHE_LOCK = threading.Lock()
 
 
 def _cached_comparison(this: "CRS", other: "CRS", mode: str) -> bool:
-    key = (this.srs, other.srs, mode)
+    # PROJ's comparisons are symmetric, so order the srs pair to let
+    # a-vs-b and b-vs-a share an entry.
+    srs1, srs2 = this.srs, other.srs
+    key = (srs1, srs2, mode) if srs1 <= srs2 else (srs2, srs1, mode)
     try:
         return _COMPARISON_CACHE[key]
     except KeyError:
@@ -85,7 +88,8 @@ def _cached_comparison(this: "CRS", other: "CRS", mode: str) -> bool:
     else:
         result = this._crs.equals(other._crs, ignore_axis_order=mode == "ignore_axis")
     with _COMPARISON_CACHE_LOCK:
-        # bound the cache, evicting the oldest entries first
+        # bound the cache, evicting in insertion order (FIFO, not LRU: hits
+        # are served without taking the lock)
         while len(_COMPARISON_CACHE) >= _COMPARISON_CACHE_MAXSIZE:
             _COMPARISON_CACHE.popitem(last=False)
         _COMPARISON_CACHE[key] = result

--- a/pyproj/crs/crs.py
+++ b/pyproj/crs/crs.py
@@ -8,6 +8,7 @@ import json
 import re
 import threading
 import warnings
+from collections import OrderedDict
 from collections.abc import Callable
 from typing import Any, Optional
 
@@ -62,6 +63,33 @@ class CRSLocal(threading.local):
     def __init__(self):
         self.crs = None  # Initialises in each thread
         super().__init__()
+
+
+_COMPARISON_CACHE_MAXSIZE = 256
+# Comparison results, keyed on (srs, srs, mode). PROJ's comparison recurses
+# through the datum, coordinate system and conversion of both objects and is
+# expensive, but the result only depends on the two input strings.
+_COMPARISON_CACHE: OrderedDict[tuple[str, str, str], bool] = OrderedDict()
+# Guards mutation of _COMPARISON_CACHE
+_COMPARISON_CACHE_LOCK = threading.Lock()
+
+
+def _cached_comparison(this: "CRS", other: "CRS", mode: str) -> bool:
+    key = (this.srs, other.srs, mode)
+    try:
+        return _COMPARISON_CACHE[key]
+    except KeyError:
+        pass
+    if mode == "exact":
+        result = this._crs.is_exact_same(other._crs)
+    else:
+        result = this._crs.equals(other._crs, ignore_axis_order=mode == "ignore_axis")
+    with _COMPARISON_CACHE_LOCK:
+        # bound the cache, evicting the oldest entries first
+        while len(_COMPARISON_CACHE) >= _COMPARISON_CACHE_MAXSIZE:
+            _COMPARISON_CACHE.popitem(last=False)
+        _COMPARISON_CACHE[key] = result
+    return result
 
 
 def _prepare_from_dict(projparams: dict[str, Any], allow_json: bool = True) -> str:
@@ -181,6 +209,9 @@ class CRS:
         The string form of the user input used to create the CRS.
 
     """  # noqa: E501
+
+    # cached by __hash__ on first use; None until then
+    _hash: int | None = None
 
     def __init__(self, projparams: Any | None = None, **kwargs) -> None:
         """
@@ -937,6 +968,22 @@ class CRS:
                 cf_axis_list.extend(sub_crs.cs_to_cf())
         return cf_axis_list
 
+    def _compare(self, other: Any, mode: str) -> bool:
+        """
+        Compare to another CRS, taking the cheapest path that gives the answer.
+        """
+        if self is other:
+            return True
+        if not isinstance(other, CRS):
+            try:
+                other = CRS.from_user_input(other)
+            except CRSError:
+                return False
+        # identical input always builds identical PROJ objects
+        if self.srs == other.srs:
+            return True
+        return _cached_comparison(self, other, mode)
+
     def is_exact_same(self, other: Any) -> bool:
         """
         Check if the CRS objects are the exact same.
@@ -952,11 +999,7 @@ class CRS:
         -------
         bool
         """
-        try:
-            other = CRS.from_user_input(other)
-        except CRSError:
-            return False
-        return self._crs.is_exact_same(other._crs)
+        return self._compare(other, "exact")
 
     def equals(self, other: Any, ignore_axis_order: bool = False) -> bool:
         """
@@ -978,11 +1021,9 @@ class CRS:
         -------
         bool
         """
-        try:
-            other = CRS.from_user_input(other)
-        except CRSError:
-            return False
-        return self._crs.equals(other._crs, ignore_axis_order=ignore_axis_order)
+        return self._compare(
+            other, "ignore_axis" if ignore_axis_order else "equivalent"
+        )
 
     @property
     def geodetic_crs(self) -> Optional["CRS"]:
@@ -1601,7 +1642,10 @@ class CRS:
         self._local = CRSLocal()
 
     def __hash__(self) -> int:
-        return hash(self.to_wkt())
+        # to_wkt() is expensive and a CRS never changes, so cache the hash.
+        if self._hash is None:
+            self._hash = hash(self.to_wkt())
+        return self._hash
 
     def __str__(self) -> str:
         return self.srs

--- a/test/crs/test_crs.py
+++ b/test/crs/test_crs.py
@@ -1587,6 +1587,51 @@ def test_crs_equals__ignore_axis_order():
 
 
 @pytest.mark.parametrize(
+    "crs_input_a,crs_input_b",
+    [
+        ("EPSG:4326", "EPSG:4326"),
+        ("EPSG:26915+5717", "EPSG:26915+5717"),
+        ("EPSG:32610", "EPSG:32611"),
+        ("EPSG:32610", "+proj=utm +zone=10 +datum=WGS84 +units=m +no_defs"),
+        ("EPSG:4326", "OGC:CRS84"),
+    ],
+)
+def test_crs_equals__matches_proj(crs_input_a, crs_input_b):
+    """the fast paths and the cache agree with PROJ, cold and warm"""
+    crs = CRS(crs_input_a)
+    other = CRS(crs_input_b)
+    for _ in range(2):
+        assert crs.equals(other) is crs._crs.equals(other._crs)
+        assert crs.equals(other, ignore_axis_order=True) is crs._crs.equals(
+            other._crs, ignore_axis_order=True
+        )
+        assert crs.is_exact_same(other) is crs._crs.is_exact_same(other._crs)
+    assert crs.equals(crs) and crs.is_exact_same(crs)
+
+
+def test_crs_comparison_cache():
+    """repeats are served from the cache, which stays bounded and never stale"""
+    cache = pyproj.crs.crs._COMPARISON_CACHE
+    maxsize = pyproj.crs.crs._COMPARISON_CACHE_MAXSIZE
+    cache.clear()
+    crs = CRS("EPSG:32610")
+    other = CRS("EPSG:32611")
+    assert crs.equals(other) is False
+    assert crs.equals(other) is False
+    assert len(cache) == 1
+    for lon_0 in range(maxsize * 2):
+        CRS(f"+proj=eqc +lon_0={lon_0} +datum=WGS84 +units=m +no_defs").equals(crs)
+    assert len(cache) <= maxsize
+    assert crs.equals(other) is False
+
+
+def test_crs_hash__cached():
+    """repeated hashing returns a stable value"""
+    crs = CRS.from_epsg(3857)
+    assert hash(crs) == hash(crs) == hash(crs.to_wkt())
+
+
+@pytest.mark.parametrize(
     "crs_input",
     [
         "+proj=utm +zone=15",

--- a/test/crs/test_crs.py
+++ b/test/crs/test_crs.py
@@ -1625,6 +1625,18 @@ def test_crs_comparison_cache():
     assert crs.equals(other) is False
 
 
+def test_crs_comparison_cache__order_independent():
+    """the reversed comparison is served by the entry the forward one wrote"""
+    cache = pyproj.crs.crs._COMPARISON_CACHE
+    cache.clear()
+    crs = CRS("EPSG:32610")
+    other = CRS("EPSG:3857")
+    assert crs.equals(other) is False
+    assert len(cache) == 1
+    assert other.equals(crs) is False
+    assert len(cache) == 1
+
+
 def test_crs_hash__cached():
     """repeated hashing returns a stable value"""
     crs = CRS.from_epsg(3857)


### PR DESCRIPTION
Comparing two CRS objects goes through PROJ's proj_is_equivalent_to, which short-circuits on matching identifiers (EPSG codes) but otherwise falls through to a full recursive structural comparison of the datum, ellipsoid, prime meridian, coordinate system and conversion. For CRS built from PROJ strings, which carry no identifier, that costs 11-15us per comparison.

Noticed this in Cartopy where we do a check to see if `self == src_crs` to try and speed up transforms, but the CRS comparison itself can be slow.
https://github.com/SciTools/cartopy/blob/bdb6cc45e27ff4fe71741b445ac15449aee35ba3/lib/cartopy/crs.py#L410

The short circuits are the simple portion `is self` and `srs1 == srs2`, but the problem is that in missing cases we will still fall back to PROJ comparisons which is why I added the cache portion here which is really to speed up the != comparisons.

<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Tests added
 - [x] Fully documented, including `history.rst` for all changes and `api/*.rst` for new API
