### PR TITLE
Fix build CI pulling in free-threaded python

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -32,6 +32,7 @@ jobs:
           environment-name: sdist_env
           create-args: >-
             python-build
+            python-gil
             twine>=1.12
             cython
             proj=${{ env.PROJ_VERSION }}


### PR DESCRIPTION
I can't find all the discussions on this at the moment but I think conda/conda-forge sometimes accidentally pulls in the free-threaded python build instead of the normal GIL python. This is my first guess at why `twine` is not finding `pkg_resources` which should be a dependency of a dependency iirc. This should fix #1623 at least as a quick fix.

 - [x] Closes #1623
 - [ ] Tests added
 - [ ] Fully documented, including `history.rst` for all changes and `api/*.rst` for new API
