### PR TITLE
BUG: Fix CRS.to_2d() on CustomConstructorCRS subclasses

### DIFF
--- a/docs/history.rst
+++ b/docs/history.rst
@@ -16,6 +16,7 @@ Latest
 - DOC: Update fiona CRS compatibility for fiona 1.9+ (issue #1360)
 - BUG: Clear CONTEXT_THREAD_KEY when destroying PJ_CONTEXT (pull #1541)
 - BUG: Default skew angle for CF grid mapping oblique mercator to 90 (issue #1506)
+- BUG: Fix :meth:`pyproj.crs.CRS.to_2d` raising on :class:`pyproj.crs.CustomConstructorCRS` subclasses
 - BLD: update build-time dependencies
 - PERF: Optimize single point transformations and remove typecast warning (issue #1309)
 

--- a/pyproj/crs/crs.py
+++ b/pyproj/crs/crs.py
@@ -1794,6 +1794,23 @@ class CustomConstructorCRS(CRS):
         """
         return CRS(self._crs.to_3d(name=name))
 
+    def to_2d(self, name: str | None = None) -> "CRS":
+        """
+        .. versionadded:: 3.6.0
+
+        Convert the current CRS to the 2D version if it makes sense.
+
+        Parameters
+        ----------
+        name: str, optional
+            CRS name. Defaults to use the name of the original CRS.
+
+        Returns
+        -------
+        CRS
+        """
+        return CRS(self._crs.to_2d(name=name))
+
 
 class GeographicCRS(CustomConstructorCRS):
     """

--- a/test/crs/test_crs.py
+++ b/test/crs/test_crs.py
@@ -1744,6 +1744,7 @@ def test_inheritance__from_methods():
         assert isinstance(new_crs.source_crs, (type(None), ChildCRS))
         assert isinstance(new_crs.target_crs, (type(None), ChildCRS))
         assert isinstance(new_crs.to_3d(), ChildCRS)
+        assert isinstance(new_crs.to_2d(), ChildCRS)
         for sub_crs in new_crs.sub_crs_list:
             assert isinstance(sub_crs, ChildCRS)
 

--- a/test/crs/test_crs_maker.py
+++ b/test/crs/test_crs_maker.py
@@ -32,6 +32,8 @@ def assert_maker_inheritance_valid(new_crs, class_type):
     assert isinstance(new_crs.source_crs, (type(None), CRS))
     assert isinstance(new_crs.target_crs, (type(None), CRS))
     assert isinstance(new_crs.to_3d(), CRS)
+    assert isinstance(new_crs.to_2d(), CRS)
+    assert isinstance(new_crs.to_3d().to_2d(), CRS)
     for sub_crs in new_crs.sub_crs_list:
         assert isinstance(sub_crs, CRS)
 
@@ -343,3 +345,22 @@ def test_custom_constructor_crs():
             super().__init__(name)
 
     assert isinstance(MyCustomInit.from_epsg(4326), MyCustomInit)
+
+
+@pytest.mark.parametrize(
+    "crs_3d",
+    [
+        GeographicCRS(name="TEST", ellipsoidal_cs=Ellipsoidal3DCS()),
+        ProjectedCRS.from_json(
+            ProjectedCRS(conversion=UTMConversion(12), name="TEST").to_3d().to_json()
+        ),
+    ],
+)
+def test_custom_constructor_crs__to_2d(crs_3d):
+    assert len(crs_3d.axis_info) == 3
+    crs_2d = crs_3d.to_2d()
+    # must match what the equivalent pyproj.CRS instance returns
+    assert crs_2d == CRS(crs_3d.to_wkt()).to_2d()
+    assert len(crs_2d.axis_info) == 2
+    assert crs_2d.name == "TEST"
+    assert crs_3d.to_2d(name="OTHER").name == "OTHER"


### PR DESCRIPTION
`CustomConstructorCRS` overrides `geodetic_crs`, `source_crs`, `target_crs`, `sub_crs_list` and `to_3d` to return a plain `CRS`: the subclass constructors take different arguments. `to_2d` was added later (3.6.0) to the base class only, so it still calls `self.__class__(...)` and raises on every subclass:

```python
>>> GeographicCRS(name="TEST", ellipsoidal_cs=Ellipsoidal3DCS()).to_2d()
TypeError: Object of type _CRS is not JSON serializable
>>> ProjectedCRS.from_epsg(6933).to_2d()
CRSError: Invalid coordinate operation string: {"$schema": ...
```

`to_3d()` works on those same objects; so does plain `CRS.to_2d()`. The fix mirrors the `to_3d` override.

Tests: `to_2d` added to the shared `assert_maker_inheritance_valid` helper (covers all 7 subclasses), a new test asserting the result equals `CRS(crs_3d.to_wkt()).to_2d()`, and a `to_2d` line in `test_inheritance__from_methods`.

macOS/arm64, py3.13, PROJ 9.8.1:

- reverting only the source change → 9 new failures, base-class test still green
- the alternative fix (drop `self.__class__` from base `to_2d`) is caught by that base-class assertion — it breaks user `CRS` subclasses, which #902 supports
- rest of the suite unchanged: 25 failures before and after, identical set (16 `test_cli` sync, 8 `test_transformer`, 1 `test_crs`), all also failing on unmodified `main`

- [x] Tests added
- [x] `history.rst` updated

Drafted with Claude Opus 5 (`claude-opus-5`); I reviewed and verified the change and measurements.
