### PR TITLE
BUG: Fix use-after-free when ContextManager frees a context on anothe…

### DIFF
--- a/pyproj/_context.pyx
+++ b/pyproj/_context.pyx
@@ -203,12 +203,6 @@ cdef PJ_CONTEXT* pyproj_context_create() except *:
     """
     global _CONTEXT_MANAGER_LOCAL
 
-    # The context is looked up through threading.local alone, so the
-    # lookup and the ContextManager that destroys the context share one
-    # lifetime (the PyThreadState). A previous TSS-based lookup lived in
-    # a separate lifetime (the OS thread) and could be left pointing at
-    # an already-destroyed context.
-    # see: https://github.com/pyproj4/pyproj/issues/1622
     cdef ContextManager context_manager = _CONTEXT_MANAGER_LOCAL.context_manager
     cdef PJ_CONTEXT* pyproj_context = NULL
     if context_manager is None:

--- a/pyproj/_context.pyx
+++ b/pyproj/_context.pyx
@@ -3,7 +3,6 @@ import os
 import threading
 import warnings
 
-from cpython.pythread cimport PyThread_tss_create, PyThread_tss_get, PyThread_tss_set
 from libc.stdlib cimport free, malloc
 
 from pyproj._compat cimport cstrencode
@@ -22,8 +21,6 @@ cdef str _INTERNAL_PROJ_ERROR = None
 # global variables
 cdef bint _NETWORK_ENABLED = strtobool(os.environ.get("PROJ_NETWORK", "OFF"))
 cdef char* _CA_BUNDLE_PATH = ""
-# The key to get the context in each thread
-cdef Py_tss_t CONTEXT_THREAD_KEY
 
 
 def set_use_global_context(active=None):
@@ -177,7 +174,6 @@ cdef class ContextManager:
 
     def __dealloc__(self):
         if self.context != NULL:
-            PyThread_tss_set(&CONTEXT_THREAD_KEY, NULL)
             proj_context_destroy(self.context)
             self.context = NULL
 
@@ -207,17 +203,20 @@ cdef PJ_CONTEXT* pyproj_context_create() except *:
     """
     global _CONTEXT_MANAGER_LOCAL
 
-    if PyThread_tss_create(&CONTEXT_THREAD_KEY) != 0:
-        raise MemoryError("Unable to create key for PROJ context in thread.")
-    cdef const void *thread_pyproj_context = PyThread_tss_get(&CONTEXT_THREAD_KEY)
+    # The context is looked up through threading.local alone, so the
+    # lookup and the ContextManager that destroys the context share one
+    # lifetime (the PyThreadState). A previous TSS-based lookup lived in
+    # a separate lifetime (the OS thread) and could be left pointing at
+    # an already-destroyed context.
+    # see: https://github.com/pyproj4/pyproj/issues/1622
+    cdef ContextManager context_manager = _CONTEXT_MANAGER_LOCAL.context_manager
     cdef PJ_CONTEXT* pyproj_context = NULL
-    if thread_pyproj_context == NULL:
+    if context_manager is None:
         pyproj_context = proj_context_create()
         pyproj_context_initialize(pyproj_context)
-        PyThread_tss_set(&CONTEXT_THREAD_KEY, pyproj_context)
         _CONTEXT_MANAGER_LOCAL.context_manager = ContextManager.create(pyproj_context)
     else:
-        pyproj_context = <PJ_CONTEXT*>thread_pyproj_context
+        pyproj_context = context_manager.context
     return pyproj_context
 
 


### PR DESCRIPTION
This pull request refactors thread-local storage for PROJ contexts in pyproj/_context.pyx. It removes the low-level C thread-specific storage (TSS) mirror in favor of relying solely on Python's threading.local, which keeps context lookup and context lifetime in the same domain and avoids lifetime issues with OS threads.

PR #1541 partially addressed this by clearing the TSS slot in ContextManager.__dealloc__, but that only clears the slot on the thread that happens to run __dealloc__, not necessarily the context's owning thread. When a PROJ-backed object (e.g. a CRS, Datum, or Transformer) is created on one thread and its last reference is dropped on another, __dealloc__ runs on the wrong thread: it clears that thread's TSS slot instead of the owner's, leaving the owner's slot pointing at a freed context. This PR removes the TSS mirror entirely so there is no second slot to leave dangling.

Context management changes:

Removed all usage of PyThread_tss_* functions and CONTEXT_THREAD_KEY — no more manual C-level thread-local storage.
pyproj_context_create() now looks up the context through threading.local alone.
ContextManager.__dealloc__ no longer touches TSS; it only destroys the context.

<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Closes #1622
 - [ ] Tests added
 - [ ] Fully documented, including `history.rst` for all changes and `api/*.rst` for new API
